### PR TITLE
types: fix type errors

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,12 @@
+name: Presubmit
+on: [push]
+jobs:
+  Presubmit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+            python-version: '3.11'
+      - uses: actions/checkout@v3
+      - run: python3 -m pip install mypy black
+      - run: ./check.sh

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Files
 ### Testing
 
 Run `./test.py`
+
+### Presubmit
+
+Before creating a PR or submitting code, run `./check.sh`.  It will run tests
+than check your types and formatting.  This also runs automatically on GitHub
+when you make PRs, but it's much faster to catch problems locally first.

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+echo Testing...
+if ! ./test.py; then
+    echo FAIL: tests
+    exit 1
+fi
+
+# if this fails with "mypy: command not found" you need to install mypy
+#   python3 -m pip install mypy
+echo Running mypy to check types...
+if ! mypy --pretty .; then
+    echo FAIL: types
+    exit 1
+fi
+echo OK
+
+# if this fails with "black: command not found" you need to install black
+#    python3 -m pip install black
+echo Running black to check formatting...
+if ! black --check --diff --quiet --line-length 79 .; then
+    echo FAIL: formatting
+    exit 1
+fi
+echo OK
+

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -1,6 +1,6 @@
 from enum import Enum
-from dataclasses import dataclass, asdict
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Optional
 
 # Enums, short for enumerations, are a data type in Python used to represent a set of named values,
 # which are typically used to define a set of related constants with unique names.
@@ -24,32 +24,75 @@ class VariableType(Enum):
     NAO_ESTIMATE = "nao_estimate"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PathogenChars:
     na_type: NAType
     enveloped: Enveloped
     taxid: int
 
 
-@dataclass
-class PrevalenceVariable:
-    variable_type: VariableType
-    percentage: float
-    source: str
-    country: str
+@dataclass(kw_only=True)
+class Variable:
+    """An external piece of data"""
+
+    source: Optional[str] = None
+    country: Optional[str] = None
     state: Optional[str] = None
     county: Optional[str] = None
     number_of_participants: Optional[int] = None
-    confidence_interval: Optional[Tuple[float, float]] = None
+    confidence_interval: Optional[tuple[float, float]] = None
     methods: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+    # Remember to recursively consider each input's inputs if defined.
+    inputs: Optional[list["Variable"]] = None
 
 
-@dataclass
-class PrevalenceEstimator:
-    value: float
-    value_type: str
-    source: str
-    country: str
-    year: int
-    state: Optional[str] = None
-    county: Optional[str] = None
+@dataclass(kw_only=True)
+class Population(Variable):
+    """A number of people"""
+
+    people: float
+
+
+@dataclass(kw_only=True)
+class Prevalence(Variable):
+    """What fraction of people have this pathogen at some moment"""
+
+    infections_per_100k: float
+
+
+@dataclass(kw_only=True)
+class SheddingDuration(Variable):
+    days: float
+
+
+@dataclass(kw_only=True)
+class IncidenceRate(Variable):
+    """What fraction of people get this pathogen annually"""
+
+    annual_infections_per_100k: float
+
+    def to_prevalence(self, shedding_duration: SheddingDuration) -> Prevalence:
+        return Prevalence(
+            infections_per_100k=self.annual_infections_per_100k
+            * shedding_duration.days
+            / 365,
+            inputs=[self, shedding_duration],
+        )
+
+
+@dataclass(kw_only=True)
+class IncidenceAbsolute(Variable):
+    """How many people get this pathogen annually"""
+
+    annual_infections: float
+
+    def to_rate(self, population: Population) -> IncidenceRate:
+        return IncidenceRate(
+            annual_infections_per_100k=self.annual_infections
+            * 100000
+            / population.people,
+            inputs=[self, population],
+        )

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -37,11 +37,11 @@ class PrevalenceVariable:
     percentage: float
     source: str
     country: str
-    state: str = None
-    county: str = None
-    number_of_participants: int = None
-    confidence_interval: Tuple[float, float] = None
-    methods: str = None
+    state: Optional[str] = None
+    county: Optional[str] = None
+    number_of_participants: Optional[int] = None
+    confidence_interval: Optional[Tuple[float, float]] = None
+    methods: Optional[str] = None
 
 
 @dataclass
@@ -51,5 +51,5 @@ class PrevalenceEstimator:
     source: str
     country: str
     year: int
-    state: str = None
-    county: str = None
+    state: Optional[str] = None
+    county: Optional[str] = None

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -10,22 +10,22 @@ infection and potential symptoms, most HSV-1 infections persist lifelong."""
 
 
 pathogen_chars = PathogenChars(
-    na_type=NAType.DNA.value,
-    enveloped=Enveloped.NON_ENVELOPED.value,
+    na_type=NAType.DNA,
+    enveloped=Enveloped.NON_ENVELOPED,
     taxid=10298,
 )
 
 
 prevalence_vars = {
     "cdc_2015_2016_nhanes_seroprevalence": PrevalenceVariable(
-        variable_type=VariableType.MEASUREMENT.value,
+        variable_type=VariableType.MEASUREMENT,
         percentage=0.496,
         number_of_participants=3710,
         country="United States",
         source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
     ),
     "cdc_2015_2016_nhanes_estimate": PrevalenceVariable(
-        variable_type=VariableType.EXTERNAL_ESTIMATE.value,
+        variable_type=VariableType.EXTERNAL_ESTIMATE,
         percentage=0.478,
         country="United States",
         confidence_interval=(0.4281, 0.5277),
@@ -33,7 +33,7 @@ prevalence_vars = {
         methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
     ),
     "tear_and_saliva_prevalence": PrevalenceVariable(
-        variable_type=VariableType.MEASUREMENT.value,
+        variable_type=VariableType.MEASUREMENT,
         percentage=0.98,
         number_of_participants=50,
         country="United States",

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python3
-
 from pathogen_properties import *
-import math
 
 background = """Herpes Simplex Virus 1 is a very common herpesvirus that causes oral herpes (CDC, https://www.
 hopkinsmedicine.org/health/conditions-and-diseases/herpes-hsv1-and-hsv2), manifesting as cold sores or fever
@@ -16,28 +13,29 @@ pathogen_chars = PathogenChars(
 )
 
 
-prevalence_vars = {
-    "cdc_2015_2016_nhanes_seroprevalence": PrevalenceVariable(
-        variable_type=VariableType.MEASUREMENT,
-        percentage=0.496,
+variables = {
+    "cdc_2015_2016_nhanes_seroprevalence": Prevalence(
+        infections_per_100k=0.496 * 100000,
         number_of_participants=3710,
         country="United States",
         source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
     ),
-    "cdc_2015_2016_nhanes_estimate": PrevalenceVariable(
-        variable_type=VariableType.EXTERNAL_ESTIMATE,
-        percentage=0.478,
+    "cdc_2015_2016_nhanes_estimate": Prevalence(
+        infections_per_100k=0.478 * 100000,
         country="United States",
         confidence_interval=(0.4281, 0.5277),
         source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf#page=1",
         methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
     ),
-    "tear_and_saliva_prevalence": PrevalenceVariable(
-        variable_type=VariableType.MEASUREMENT,
-        percentage=0.98,
+    "tear_and_saliva_prevalence": Prevalence(
+        infections_per_100k=0.98 * 100000,
         number_of_participants=50,
         country="United States",
         state="Louisiana",
         source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1200985/#:~:text=Frequency%20of%20HSV%2D1%20DNA%20shedding%20over,swab%20data%20(subjects%2030%2C%2038%20not%20available).",
     ),
 }
+
+
+def estimate_prevalences():
+    return variables

--- a/pathogens/hva.py
+++ b/pathogens/hva.py
@@ -1,0 +1,64 @@
+from pathogen_properties import *
+
+background = """Hepatitis A is a vaccine-preventable liver-infection caused by the hepatitis A virus. In the US,
+it's mostly spread by individual contact. There is little seasonal variance in Hepatitis A incidence (https://www.cdc.gov/vaccines/pubs/pinkbook/hepa.html). Viral shedding persists for 1 to 3 weeks."""
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.RNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=208726,
+)
+
+variables = {
+    "us_incidence_absolute_2018": IncidenceAbsolute(
+        annual_infections=12474,
+        country="United States",
+        source="https://www.cdc.gov/hepatitis/statistics/2018surveillance/index.htm",
+        start_date="2018-01-01",
+        end_date="2018-12-31",
+    ),
+    "us_population_2018": Population(
+        people=326.8 * 1e6,
+        country="United States",
+        source="https://www.google.com/search?q=us+population+2018&oq=us+population+2018&aqs=chrome.0.69i59j0i512j0i22i30l6j0i390i650l2.5937j1j7&sourceid=chrome&ie=UTF-8",
+        start_date="2018-01-01",
+        end_date="2018-12-31",
+    ),
+    "hva_shedding_duration": SheddingDuration(
+        days=14,
+        country="United States",
+        source="https://www.cdc.gov/vaccines/pubs/pinkbook/hepa.html#:~:text=Viral%20shedding%20persists%20for%201%20to%203%20weeks.",
+    ),
+    "king_county_incidence_rate_2017": IncidenceRate(
+        annual_infections_per_100k=0.5,
+        country="United States",
+        state="Washington",
+        county="King",
+        start_date="2017-01-01",
+        end_date="2017-12-31",
+        source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
+    ),
+    "king_county_incidence_rate_2018": IncidenceRate(
+        annual_infections_per_100k=0.6,
+        country="United States",
+        state="Washington",
+        county="King",
+        start_date="2018-01-01",
+        end_date="2018-12-31",
+        source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
+    ),
+}
+
+
+def estimate_prevalences():
+    return {
+        "us_2018": variables["us_incidence_absolute_2018"]
+        .to_rate(variables["us_population_2018"])
+        .to_prevalence(variables["hva_shedding_duration"]),
+        "king_county_2017": variables[
+            "king_county_incidence_rate_2017"
+        ].to_prevalence(variables["hva_shedding_duration"]),
+        "king_county_2018": variables[
+            "king_county_incidence_rate_2018"
+        ].to_prevalence(variables["hva_shedding_duration"]),
+    }

--- a/test.py
+++ b/test.py
@@ -21,10 +21,19 @@ class TestPathogens(unittest.TestCase):
                     pathogens.pathogens[pathogen].pathogen_chars, PathogenChars
                 )
 
-                for prevalence_var_name, prevalence_var in pathogens.pathogens[
+                for variable_name, variable in pathogens.pathogens[
                     pathogen
-                ].prevalence_vars.items():
-                    self.assertIsInstance(prevalence_var, PrevalenceVariable)
+                ].variables.items():
+                    with self.subTest(variable=variable_name):
+                        self.assertIsInstance(variable, Variable)
+
+                for estimate_name, estimate in (
+                    pathogens.pathogens[pathogen]
+                    .estimate_prevalences()
+                    .items()
+                ):
+                    with self.subTest(estimate=estimate_name):
+                        self.assertIsInstance(estimate, Prevalence)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ran `mypy .` and fixed the errors it brought up.

(I think it's silly that `foo: str = None` is not treated as a more concise way of writing `foo: Optional[str] = None`, but it's not up to me.)