### PR TITLE
dataclasses: enable kw_only

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -24,14 +24,14 @@ class VariableType(Enum):
     NAO_ESTIMATE = "nao_estimate"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PathogenChars:
     na_type: NAType
     enveloped: Enveloped
     taxid: int
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PrevalenceVariable:
     variable_type: VariableType
     percentage: float
@@ -44,7 +44,7 @@ class PrevalenceVariable:
     methods: Optional[str] = None
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PrevalenceEstimator:
     value: float
     value_type: str


### PR DESCRIPTION
Creating dataclasses as `Foo(state='MA', city='Boston')` is much safer than `Foo('MA', 'Boston')` because it means if someone accidentally swaps the arguments you're more likely to notice: `Foo('Boston', 'MA')` looks fine, but `Foo(state='Boston', city='MA')` does not.

Setting `kw_only=True` on dataclasses forces this keyword calling usage.