### PR TITLE
variables: just use normal python variables

### DIFF
--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -13,29 +13,32 @@ pathogen_chars = PathogenChars(
 )
 
 
-variables = {
-    "cdc_2015_2016_nhanes_seroprevalence": Prevalence(
-        infections_per_100k=0.496 * 100000,
-        number_of_participants=3710,
-        country="United States",
-        source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
-    ),
-    "cdc_2015_2016_nhanes_estimate": Prevalence(
-        infections_per_100k=0.478 * 100000,
-        country="United States",
-        confidence_interval=(0.4281, 0.5277),
-        source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf#page=1",
-        methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
-    ),
-    "tear_and_saliva_prevalence": Prevalence(
-        infections_per_100k=0.98 * 100000,
-        number_of_participants=50,
-        country="United States",
-        state="Louisiana",
-        source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1200985/#:~:text=Frequency%20of%20HSV%2D1%20DNA%20shedding%20over,swab%20data%20(subjects%2030%2C%2038%20not%20available).",
-    ),
-}
+cdc_2015_2016_nhanes_seroprevalence = Prevalence(
+    infections_per_100k=0.496 * 100000,
+    number_of_participants=3710,
+    country="United States",
+    source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
+)
+cdc_2015_2016_nhanes_estimate = Prevalence(
+    infections_per_100k=0.478 * 100000,
+    country="United States",
+    confidence_interval=(0.4281, 0.5277),
+    source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf#page=1",
+    methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
+)
+
+tear_and_saliva_prevalence = Prevalence(
+    infections_per_100k=0.98 * 100000,
+    number_of_participants=50,
+    country="United States",
+    state="Louisiana",
+    source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1200985/#:~:text=Frequency%20of%20HSV%2D1%20DNA%20shedding%20over,swab%20data%20(subjects%2030%2C%2038%20not%20available).",
+)
 
 
 def estimate_prevalences():
-    return variables
+    return [
+        cdc_2015_2016_nhanes_seroprevalence,
+        cdc_2015_2016_nhanes_estimate,
+        tear_and_saliva_prevalence,
+    ]

--- a/test.py
+++ b/test.py
@@ -11,29 +11,14 @@ class TestPathogens(unittest.TestCase):
         self.assertIn("hsv_1", pathogens.pathogens)
 
     def test_properties_exist(self):
-        for pathogen in pathogens.pathogens:
-            with self.subTest(pathogen=pathogen):
-                self.assertIsInstance(
-                    pathogens.pathogens[pathogen].background, str
-                )
+        for pathogen_name, pathogen in pathogens.pathogens.items():
+            with self.subTest(pathogen=pathogen_name):
+                self.assertIsInstance(pathogen.background, str)
 
-                self.assertIsInstance(
-                    pathogens.pathogens[pathogen].pathogen_chars, PathogenChars
-                )
+                self.assertIsInstance(pathogen.pathogen_chars, PathogenChars)
 
-                for variable_name, variable in pathogens.pathogens[
-                    pathogen
-                ].variables.items():
-                    with self.subTest(variable=variable_name):
-                        self.assertIsInstance(variable, Variable)
-
-                for estimate_name, estimate in (
-                    pathogens.pathogens[pathogen]
-                    .estimate_prevalences()
-                    .items()
-                ):
-                    with self.subTest(estimate=estimate_name):
-                        self.assertIsInstance(estimate, Prevalence)
+                for estimate in pathogen.estimate_prevalences():
+                    self.assertIsInstance(estimate, Prevalence)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I can't see any reason to put Variables in a special dictionary; they can just be first-class variables.