### PR TITLE
Add estimate for HIV

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -42,6 +42,9 @@ class Variable:
     number_of_participants: Optional[int] = None
     confidence_interval: Optional[tuple[float, float]] = None
     methods: Optional[str] = None
+    # Either supply date, or start_date and end_date.
+    # Dates can be any of: YYYY, YYYY-MM, or YYYY-MM-DD.
+    date: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
 
@@ -71,6 +74,19 @@ class Prevalence(Variable):
         return Prevalence(
             infections_per_100k=self.infections_per_100k * scalar.scalar,
             inputs=[self, scalar],
+        )
+
+
+@dataclass(kw_only=True)
+class PrevalenceAbsolute(Variable):
+    """How many people had this pathogen at some moment"""
+
+    infections: float
+
+    def to_rate(self, population: Population) -> Prevalence:
+        return Prevalence(
+            infections_per_100k=self.infections * 100000 / population.people,
+            inputs=[self, population],
         )
 
 

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -57,15 +57,39 @@ class Population(Variable):
 
 
 @dataclass(kw_only=True)
+class Scalar(Variable):
+    scalar: float
+
+
+@dataclass(kw_only=True)
 class Prevalence(Variable):
     """What fraction of people have this pathogen at some moment"""
 
     infections_per_100k: float
 
+    def scale(self, scalar: Scalar) -> "Prevalence":
+        return Prevalence(
+            infections_per_100k=self.infections_per_100k * scalar.scalar,
+            inputs=[self, scalar],
+        )
+
 
 @dataclass(kw_only=True)
 class SheddingDuration(Variable):
     days: float
+
+
+@dataclass(kw_only=True)
+class Number(Variable):
+    """Generic number.  Use this for weird one-off things
+
+    If some concept is being used by more than two estimates it should get a
+    more specific Variable subclass."""
+
+    number: float
+
+    def per(self, other: "Number") -> Scalar:
+        return Scalar(scalar=self.number / other.number, inputs=[self, other])
 
 
 @dataclass(kw_only=True)

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -1,0 +1,72 @@
+from pathogen_properties import *
+
+background = """HIV is a sexually-transmitted retrovirus which gradually
+weakens the immune system."""
+
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.RNA,
+    enveloped=Enveloped.ENVELOPED,
+    taxid=11676,
+)
+
+# Controlled HIV has basically no sheddding, and we're really only interested
+# in uncontrolled HIV.  The CDC estimates that 57% of Americans with HIV were
+# virally suppressed in 2019.
+us_unsuppressed_fraction_2019 = Scalar(
+    scalar=1 - 0.57,
+    country="United States",
+    date="2019",
+    source="https://www.cdc.gov/hiv/library/reports/hiv-surveillance/vol-26-no-2/content/national-profile.html#:~:text=57%25%20were%20virally%20suppressed",
+)
+
+us_infected_2019 = PrevalenceAbsolute(
+    infections=1.2e6,
+    country="United States",
+    source="https://www.cdc.gov/hiv/library/reports/hiv-surveillance/vol-26-no-2/content/national-profile.html#:~:text=Among%20the%20estimated-,1.2%20million%20people,-living%20with%20HIV",
+)
+
+us_population_2019 = Population(
+    people=328_231_337,
+    country="United States",
+    source="https://www.census.gov/newsroom/press-releases/2019/new-years-population.html",
+    date="2019-01-01",
+)
+
+la_unsuppressed_fraction_2020 = Scalar(
+    scalar=1 - 0.6,
+    country="United States",
+    state="California",
+    county="Los Angeles",
+    date="2020",
+    source="https://web.archive.org/web/20201202004910/https://www.lacounty.hiv/",
+)
+
+la_infected_2020 = PrevalenceAbsolute(
+    infections=57_700,
+    country="United States",
+    state="California",
+    county="Los Angeles",
+    date="2020",
+    source="https://web.archive.org/web/20201202004910/https://www.lacounty.hiv/",
+)
+
+la_population_2020 = Population(
+    people=10_014_009,
+    country="United States",
+    state="California",
+    county="Los Angeles",
+    date="2020-04-01",
+    source="https://www.census.gov/quickfacts/losangelescountycalifornia",
+)
+
+
+def estimate_prevalences():
+    return [
+        us_infected_2019.to_rate(us_population_2019).scale(
+            us_unsuppressed_fraction_2019
+        ),
+        la_infected_2020.to_rate(la_population_2020).scale(
+            la_unsuppressed_fraction_2020
+        ),
+    ]

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -23,6 +23,7 @@ us_unsuppressed_fraction_2019 = Scalar(
 us_infected_2019 = PrevalenceAbsolute(
     infections=1.2e6,
     country="United States",
+    date="2019"
     source="https://www.cdc.gov/hiv/library/reports/hiv-surveillance/vol-26-no-2/content/national-profile.html#:~:text=Among%20the%20estimated-,1.2%20million%20people,-living%20with%20HIV",
 )
 

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -23,7 +23,7 @@ us_unsuppressed_fraction_2019 = Scalar(
 us_infected_2019 = PrevalenceAbsolute(
     infections=1.2e6,
     country="United States",
-    date="2019"
+    date="2019",
     source="https://www.cdc.gov/hiv/library/reports/hiv-surveillance/vol-26-no-2/content/national-profile.html#:~:text=Among%20the%20estimated-,1.2%20million%20people,-living%20with%20HIV",
 )
 

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -11,46 +11,42 @@ pathogen_chars = PathogenChars(
 )
 
 
-variables = {
-    "cases": IncidenceAbsolute(
-        annual_infections=20e6,
-        confidence_interval=(19e6, 21e6),
-        country="United States",
-        source="https://www.cdc.gov/norovirus/trends-outbreaks/burden-US.html",
-    ),
-    "us_population": Population(
-        people=333_287_557,
-        country="United States",
-        source="https://www.census.gov/quickfacts/fact/table/US/PST045221",
-        start_date="2022-07-01",
-        end_date="2022-07-01",
-    ),
-    "shedding_duration": SheddingDuration(
-        days=2,
-        confidence_interval=(1, 3),
-        source="https://www.mayoclinic.org/diseases-conditions/norovirus/symptoms-causes/syc-20355296",
-    ),
-    "rothman_period_outbreaks": Number(
-        number=13 / 5,  # monthly outbreaks
-        country="United States",
-        source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
-    ),
-    "normal_year_outbreaks": Number(
-        number=1246 / 12,  # monthly outbreaks
-        country="United States",
-        source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
-    ),
-}
+cases = IncidenceAbsolute(
+    annual_infections=20e6,
+    confidence_interval=(19e6, 21e6),
+    country="United States",
+    source="https://www.cdc.gov/norovirus/trends-outbreaks/burden-US.html",
+)
+
+us_population = Population(
+    people=333_287_557,
+    country="United States",
+    source="https://www.census.gov/quickfacts/fact/table/US/PST045221",
+    start_date="2022-07-01",
+    end_date="2022-07-01",
+)
+
+shedding_duration = SheddingDuration(
+    days=2,
+    confidence_interval=(1, 3),
+    source="https://www.mayoclinic.org/diseases-conditions/norovirus/symptoms-causes/syc-20355296",
+)
+
+rothman_period_outbreaks = Number(
+    number=13 / 5,  # 13 outbreaks over 5 months
+    country="United States",
+    source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
+)
+normal_year_outbreaks = Number(
+    number=1246 / 12,  # 1246 outbreaks over one year
+    country="United States",
+    source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
+)
 
 
 def estimate_prevalences():
-    return {
-        "rothman_2021_period": variables["cases"]
-        .to_rate(variables["us_population"])
-        .to_prevalence(variables["shedding_duration"])
-        .scale(
-            variables["rothman_period_outbreaks"].per(
-                variables["normal_year_outbreaks"]
-            )
-        )
-    }
+    return [
+        cases.to_rate(us_population)
+        .to_prevalence(shedding_duration)
+        .scale(rothman_period_outbreaks.per(normal_year_outbreaks))
+    ]

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -1,0 +1,56 @@
+from pathogen_properties import *
+
+background = """Norivirus in a GI infection, mostly spread through personal
+contact."""
+
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.RNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=142786,
+)
+
+
+variables = {
+    "cases": IncidenceAbsolute(
+        annual_infections=20e6,
+        confidence_interval=(19e6, 21e6),
+        country="United States",
+        source="https://www.cdc.gov/norovirus/trends-outbreaks/burden-US.html",
+    ),
+    "us_population": Population(
+        people=333_287_557,
+        country="United States",
+        source="https://www.census.gov/quickfacts/fact/table/US/PST045221",
+        start_date="2022-07-01",
+        end_date="2022-07-01",
+    ),
+    "shedding_duration": SheddingDuration(
+        days=2,
+        confidence_interval=(1, 3),
+        source="https://www.mayoclinic.org/diseases-conditions/norovirus/symptoms-causes/syc-20355296",
+    ),
+    "rothman_period_outbreaks": Number(
+        number=13 / 5,  # monthly outbreaks
+        country="United States",
+        source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
+    ),
+    "normal_year_outbreaks": Number(
+        number=1246 / 12,  # monthly outbreaks
+        country="United States",
+        source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
+    ),
+}
+
+
+def estimate_prevalences():
+    return {
+        "rothman_2021_period": variables["cases"]
+        .to_rate(variables["us_population"])
+        .to_prevalence(variables["shedding_duration"])
+        .scale(
+            variables["rothman_period_outbreaks"].per(
+                variables["normal_year_outbreaks"]
+            )
+        )
+    }

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -1,6 +1,6 @@
 from pathogen_properties import *
 
-background = """Norivirus in a GI infection, mostly spread through personal
+background = """Norovirus in a GI infection, mostly spread through personal
 contact."""
 
 

--- a/summarize.py
+++ b/summarize.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import pathogens
+
+
+def start():
+    for pathogen_name, pathogen in pathogens.pathogens.items():
+        print(pathogen_name)
+        for estimate_name, estimate in pathogen.estimate_prevalences().items():
+            print(
+                "  %s: %.2f per 100k"
+                % (estimate_name, estimate.infections_per_100k)
+            )
+
+
+if __name__ == "__main__":
+    start()

--- a/summarize.py
+++ b/summarize.py
@@ -6,11 +6,8 @@ import pathogens
 def start():
     for pathogen_name, pathogen in pathogens.pathogens.items():
         print(pathogen_name)
-        for estimate_name, estimate in pathogen.estimate_prevalences().items():
-            print(
-                "  %s: %.2f per 100k"
-                % (estimate_name, estimate.infections_per_100k)
-            )
+        for estimate in pathogen.estimate_prevalences():
+            print("  %.2f per 100k" % estimate.infections_per_100k)
 
 
 if __name__ == "__main__":

--- a/summarize.py
+++ b/summarize.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
+import sys
 
 import pathogens
 
 
-def start():
+def start(pathogen_names):
     for pathogen_name, pathogen in pathogens.pathogens.items():
+        if pathogen_names and pathogen_name not in pathogen_names:
+            continue
         print(pathogen_name)
         for estimate in pathogen.estimate_prevalences():
             print("  %.2f per 100k" % estimate.infections_per_100k)
 
 
 if __name__ == "__main__":
-    start()
+    start(sys.argv[1:])

--- a/test.py
+++ b/test.py
@@ -14,6 +14,7 @@ class TestPathogens(unittest.TestCase):
         for pathogen_name, pathogen in pathogens.pathogens.items():
             with self.subTest(pathogen=pathogen_name):
                 self.assertIsInstance(pathogen.background, str)
+
                 self.assertIsInstance(pathogen.pathogen_chars, PathogenChars)
 
                 for estimate in pathogen.estimate_prevalences():

--- a/test.py
+++ b/test.py
@@ -11,27 +11,19 @@ class TestPathogens(unittest.TestCase):
         self.assertIn("hsv_1", pathogens.pathogens)
 
     def test_properties_exist(self):
-        for pathogen in pathogens.pathogens:
-            with self.subTest(pathogen=pathogen):
-                self.assertIsInstance(
-                    pathogens.pathogens[pathogen].background, str
-                )
+        for pathogen_name, pathogen in pathogens.pathogens.items():
+            with self.subTest(pathogen=pathogen_name):
+                self.assertIsInstance(pathogen.background, str)
+                self.assertIsInstance(pathogen.pathogen_chars, PathogenChars)
 
-                self.assertIsInstance(
-                    pathogens.pathogens[pathogen].pathogen_chars, PathogenChars
-                )
-
-                for variable_name, variable in pathogens.pathogens[
-                    pathogen
-                ].variables.items():
+                for variable_name, variable in pathogen.variables.items():
                     with self.subTest(variable=variable_name):
                         self.assertIsInstance(variable, Variable)
 
-                for estimate_name, estimate in (
-                    pathogens.pathogens[pathogen]
-                    .estimate_prevalences()
-                    .items()
-                ):
+                for (
+                    estimate_name,
+                    estimate,
+                ) in pathogen.estimate_prevalences().items():
                     with self.subTest(estimate=estimate_name):
                         self.assertIsInstance(estimate, Prevalence)
 

--- a/test.py
+++ b/test.py
@@ -18,7 +18,6 @@ class TestPathogens(unittest.TestCase):
 
                 for estimate in pathogen.estimate_prevalences():
                     self.assertIsInstance(estimate, Prevalence)
->>>>>>> jefftk-normal-vars
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I looked a little deeper and instead of using the unaware fraction as a proxy for viral suppressing it turns out viral suppression statistics are already collected.  Use those instead.

```
$ ./summarize.py hiv
hiv
  157.21 per 100k
  230.48 per 100k
```

Infrastructure changes:
 - Added PrevalenceAbsolute
 - Let you specify a single date for Variable
 - `summarize.py` supports specifying a pathogen