### PR TITLE
prevalence: add a concept of a target

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -48,6 +48,7 @@ class Variable:
     date: Optional[str] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
+    is_target: Optional[bool] = False
 
     # Remember to recursively consider each input's inputs if defined.
     inputs: Optional[list["Variable"]] = None
@@ -66,7 +67,7 @@ class Variable:
         location = self._location()
         if location:
             all_locations.add(location)
-        if self.inputs:
+        if self.inputs and not self.is_target:
             for variable in self.inputs:
                 variable._collect_locations(all_locations)
 
@@ -79,7 +80,7 @@ class Variable:
         for date in [self.date, self.start_date, self.end_date]:
             if date:
                 all_dates.add(date)
-        if self.inputs:
+        if self.inputs and not self.is_target:
             for variable in self.inputs:
                 variable._collect_dates(all_dates)
 
@@ -152,6 +153,14 @@ class Prevalence(Variable):
         return Prevalence(
             infections_per_100k=self.infections_per_100k * scalar.scalar,
             inputs=[self, scalar],
+        )
+
+    def target(self, **kwargs) -> "Prevalence":
+        return Prevalence(
+            infections_per_100k=self.infections_per_100k,
+            inputs=[self],
+            is_target=True,
+            **kwargs
         )
 
 

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -88,19 +88,26 @@ def estimate_prevalences():
                 latest.pop(0)
                 latest.append(delta)
 
+                # centered moving average
+                # https://www.jefftk.com/p/careful-with-trailing-averages
+                date = str(day - datetime.timedelta(days=3))
                 cases = IncidenceAbsolute(
                     annual_infections=sum(latest) * 52,
                     country="United States",
                     state="California",
                     county=county,
-                    # centered moving average
-                    # https://www.jefftk.com/p/careful-with-trailing-averages
-                    date=str(day - datetime.timedelta(days=3)),
+                    date=date,
                 )
                 estimates.append(
                     cases.to_rate(county_populations[county])
                     .to_prevalence(shedding_duration)
                     .scale(underreporting)
+                    .target(
+                        country="United States",
+                        state="California",
+                        county=county,
+                        date=date,
+                    )
                 )
 
         return estimates


### PR DESCRIPTION
A prevalence estimate can target a particular location or date, which is not quite the same as being derived from information about particular locations or dates.  Make it explicit when we do have a target.

This PR just adds one for covid; if we like this I can go back and add ones for other pathogens.

Before:

```
$ ./summarize.py sars_cov_2 | head
sars_cov_2
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
```

After:

```
$ ./summarize.py sars_cov_2 | head
sars_cov_2
  0.00 per 100k (Los Angeles, California, United States; 2020-01-20)
  0.00 per 100k (Los Angeles, California, United States; 2020-01-21)
  0.00 per 100k (Los Angeles, California, United States; 2020-01-22)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-23)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-24)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-25)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-26)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-27)
  0.10 per 100k (Los Angeles, California, United States; 2020-01-28)
```