### PR TITLE
summarize: include a maximum number of estimates for a single pathogen

### DIFF
--- a/summarize.py
+++ b/summarize.py
@@ -12,10 +12,11 @@ def start(pathogen_names):
             continue
 
         print(pathogen_name)
+        skipped = 0
         for n, estimate in enumerate(pathogen.estimate_prevalences()):
             if n > MAX_ESTIMATES_FOR_PATHOGEN:
-                print("  ...")
-                break
+                skipped += 1
+                continue
             print(
                 "  %.2f per 100k (%s; %s)"
                 % (
@@ -24,6 +25,8 @@ def start(pathogen_names):
                     estimate.summarize_date(),
                 )
             )
+        if skipped:
+            print("  + %s more" % skipped)
 
 
 if __name__ == "__main__":

--- a/summarize.py
+++ b/summarize.py
@@ -3,6 +3,8 @@ import sys
 
 import pathogens
 
+MAX_ESTIMATES_FOR_PATHOGEN = 5
+
 
 def start(pathogen_names):
     for pathogen_name, pathogen in pathogens.pathogens.items():
@@ -10,7 +12,10 @@ def start(pathogen_names):
             continue
 
         print(pathogen_name)
-        for estimate in pathogen.estimate_prevalences():
+        for n, estimate in enumerate(pathogen.estimate_prevalences()):
+            if n > MAX_ESTIMATES_FOR_PATHOGEN:
+                print("  ...")
+                break
             print(
                 "  %.2f per 100k (%s; %s)"
                 % (


### PR DESCRIPTION
Covid has daily estimates, which overwhelms the output and you can't see anything else.  For now, just limit each pathogen to five records.

Before:

```
./summarize.py sars_cov_2
sars_cov_2
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  [manually snipped 2000+ lines]
```

After:

```
 $ ./summarize.py sars_cov_2
sars_cov_2
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.00 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  0.10 per 100k (Los Angeles, California, United States; United States; 2020 to 2021)
  + 2895 more
```