### PR TITLE
Taxids

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -1,7 +1,7 @@
 import os.path
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import NewType, Optional
 
 # Enums, short for enumerations, are a data type in Python used to represent a set of named values,
 # which are typically used to define a set of related constants with unique names.
@@ -25,11 +25,14 @@ class VariableType(Enum):
     NAO_ESTIMATE = "nao_estimate"
 
 
+TaxID = NewType("TaxID", int)
+
+
 @dataclass(kw_only=True)
 class PathogenChars:
     na_type: NAType
     enveloped: Enveloped
-    taxid: int
+    taxid: TaxID
 
 
 @dataclass(kw_only=True)

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -7,7 +7,7 @@ weakens the immune system."""
 pathogen_chars = PathogenChars(
     na_type=NAType.RNA,
     enveloped=Enveloped.ENVELOPED,
-    taxid=11676,
+    taxid=TaxID(11676),
 )
 
 # Controlled HIV has basically no sheddding, and we're really only interested

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -9,7 +9,7 @@ infection and potential symptoms, most HSV-1 infections persist lifelong."""
 pathogen_chars = PathogenChars(
     na_type=NAType.DNA,
     enveloped=Enveloped.NON_ENVELOPED,
-    taxid=10298,
+    taxid=TaxID(10298),
 )
 
 

--- a/pathogens/hva.py
+++ b/pathogens/hva.py
@@ -10,7 +10,7 @@ weeks."""
 pathogen_chars = PathogenChars(
     na_type=NAType.RNA,
     enveloped=Enveloped.NON_ENVELOPED,
-    taxid=208726,
+    taxid=TaxID(208726),
 )
 
 

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -7,7 +7,7 @@ contact."""
 pathogen_chars = PathogenChars(
     na_type=NAType.RNA,
     enveloped=Enveloped.NON_ENVELOPED,
-    taxid=142786,
+    taxid=TaxID(142786),
 )
 
 

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -9,7 +9,7 @@ background = """SARS-CoV-2 is an airborne coronavirus, responsible for the
 pathogen_chars = PathogenChars(
     na_type=NAType.RNA,
     enveloped=Enveloped.ENVELOPED,
-    taxid=2697049,
+    taxid=TaxID(2697049),
 )
 
 shedding_duration = SheddingDuration(


### PR DESCRIPTION
Resolves #28. There are two versions here in successive commits. The first commit does the simple thing of representing TaxID as a NewType of int. The second commit changes it to a datatype so that it can be initialized with (appropriate) strings as well. @jeffkaufman do you have a preference?