### PR TITLE
dates: parse dates

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import datetime
 import unittest
 from collections import Counter
 
@@ -33,6 +34,57 @@ class TestPathogens(unittest.TestCase):
 
                 for estimate in pathogen.estimate_prevalences():
                     self.assertIsInstance(estimate, Prevalence)
+
+
+class TestVaribles(unittest.TestCase):
+    def test_date_parsing(self):
+        v = Variable(date="2019")
+        self.assertEqual(v.parsed_start, datetime.date(2019, 1, 1))
+        self.assertEqual(v.parsed_end, datetime.date(2019, 12, 31))
+
+        v = Variable(date="2019-02")
+        self.assertEqual(v.parsed_start, datetime.date(2019, 2, 1))
+        self.assertEqual(v.parsed_end, datetime.date(2019, 2, 28))
+
+        v = Variable(date="2020-02")
+        self.assertEqual(v.parsed_start, datetime.date(2020, 2, 1))
+        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 29))
+
+        v = Variable(date="2020-02-01")
+        self.assertEqual(v.parsed_start, datetime.date(2020, 2, 1))
+        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 1))
+
+        v = Variable(start_date="2020-01", end_date="2020-02")
+        self.assertEqual(v.parsed_start, datetime.date(2020, 1, 1))
+        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 29))
+
+        v = Variable(start_date="2020-01-07", end_date="2020-02-06")
+        self.assertEqual(v.parsed_start, datetime.date(2020, 1, 7))
+        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 6))
+
+        with self.assertRaises(Exception):
+            Variable(start_date="2020-01-07")
+
+        with self.assertRaises(Exception):
+            Variable(end_date="2020-01-07")
+
+        with self.assertRaises(Exception):
+            Variable(start_date="2020-01-07", date="2020")
+
+        with self.assertRaises(Exception):
+            Variable(end_date="2020-01-07", date="2020")
+
+        with self.assertRaises(Exception):
+            Variable(start_date="2020-01-07", end_date="2020-01-06")
+
+        with self.assertRaises(Exception):
+            Variable(date="2020-1")
+
+        with self.assertRaises(Exception):
+            Variable(date="2020/1/1")
+
+        with self.assertRaises(Exception):
+            Variable(date="2020/01/01")
 
 
 class TestMGS(unittest.TestCase):


### PR DESCRIPTION
Use a post-init hook to parse dates.  This lets people keep entering dates in the easiest form, but still provides machine-readable dates for later processing.

Fixes #39