### PR TITLE
Pin specific commit of MGS repo

### DIFF
--- a/get_rothman_virus_counts.py
+++ b/get_rothman_virus_counts.py
@@ -5,7 +5,9 @@ from pathogens import pathogens
 
 if __name__ == "__main__":
     repo = mgs.GitHubRepo(
-        user="naobservatory", repo="mgs-pipeline", branch="main"
+        user="naobservatory",
+        repo="mgs-pipeline",
+        branch="47e2025f35168d3f414ae62928f6a14dd3f7c23d",
     )
     bp_data = mgs.load_bioprojects(repo)
     sample_data = mgs.load_sample_attributes(repo)

--- a/test.py
+++ b/test.py
@@ -37,7 +37,9 @@ class TestPathogens(unittest.TestCase):
 
 class TestMGS(unittest.TestCase):
     repo = mgs.GitHubRepo(
-        user="naobservatory", repo="mgs-pipeline", branch="main"
+        user="naobservatory",
+        repo="mgs-pipeline",
+        branch="47e2025f35168d3f414ae62928f6a14dd3f7c23d",
     )
 
     def test_load_bioprojects(self):


### PR DESCRIPTION
MGS code now pulls from a specific commit of the mgs-pipeline repo so that updates to the data there don't cause errors or change the results.