### PR TITLE
check: add --fix option to automatically reformat code and sort imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Before creating a PR or submitting code, run `./check.sh`.  It will run tests
 than check your types and formatting.  This also runs automatically on GitHub
 when you make PRs, but it's much faster to catch problems locally first.
 
+If `./check.sh` complains about formatting or import sorting, you can fix this
+automatically with `./check.sh --fix`.
+
 #### Installing pystan
 
 Pystan should be installed along with the other requirements when you run:

--- a/check.sh
+++ b/check.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
+CHANGED=0
 if [[ $# = 1 ]] && [[ "$1" = "--fix" ]]; then
-    black . || exit 1
-    isort . || exit 1
+    if ! black --check . &> /dev/null; then
+        black . || exit 1
+        CHANGED=1
+    fi
+
+    if ! isort --check . &> /dev/null; then
+        isort . || exit 1
+        CHANGED=1
+    fi
 elif [[ $# -gt 0 ]]; then
     echo "Usage: $0 [--fix]" > /dev/stderr
     exit 1
@@ -10,7 +18,7 @@ fi
 
 echo Testing...
 if ! ./test.py; then
-    echo FAIL: tests
+    echo "FAIL: tests"
     exit 1
 fi
 
@@ -18,25 +26,28 @@ fi
 #   python3 -m pip install mypy
 echo Running mypy to check types...
 if ! mypy --pretty .; then
-    echo FAIL: types
+    echo "FAIL: types"
     exit 1
 fi
-echo OK
 
 # if this fails with "black: command not found" you need to install black
 #    python3 -m pip install black
 echo Running black to check formatting...
 if ! black --check --diff --quiet .; then
-    echo FAIL: formatting
+    echo "FAIL: formatting"
     exit 1
 fi
-echo OK
 
 # if this fails with "isort: command not found" you need to install isort 
 #    python3 -m pip install isort
 echo Running isort to check import sorting...
 if ! isort --check --quiet .; then
-    echo FAIL: import sorting 
+    echo "FAIL: import sorting"
     exit 1
 fi
-echo OK
+
+if [[ $CHANGED = 1 ]]; then
+    echo "OK after fixes"
+else
+    echo "OK"
+fi

--- a/check.sh
+++ b/check.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+if [[ $# = 1 ]] && [[ "$1" = "--fix" ]]; then
+    black . || exit 1
+    isort . || exit 1
+elif [[ $# -gt 0 ]]; then
+    echo "Usage: $0 [--fix]" > /dev/stderr
+    exit 1
+fi
+
 echo Testing...
 if ! ./test.py; then
     echo FAIL: tests


### PR DESCRIPTION
This has some manual argument parsing.  I think this is fine since we're only doing one optional argument, though if we later add more we should switch to `getops` or something.

```
$ ./check.sh --fix
reformatted /Users/jeffkaufman/code/p2ra/pathogen_properties.py

All done! ✨ 🍰 ✨
1 file reformatted, 13 files left unchanged.
Fixing /Users/jeffkaufman/code/p2ra/pathogen_properties.py
Skipped 2 files
Testing...
................
----------------------------------------------------------------------
Ran 16 tests in 0.817s

OK
Running mypy to check types...
Success: no issues found in 14 source files
Running black to check formatting...
Running isort to check import sorting...
OK after fixes
```

And then if I run it again:

```
$ ./check.sh --fix
Testing...
................
----------------------------------------------------------------------
Ran 16 tests in 2.375s

OK
Running mypy to check types...
Success: no issues found in 14 source files
Running black to check formatting...
Running isort to check import sorting...
OK
```