### PR TITLE
summarize: display tweaks

### DIFF
--- a/summarize.py
+++ b/summarize.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import calendar
 import sys
 
 import pathogens
@@ -7,21 +8,23 @@ MAX_ESTIMATES_FOR_PATHOGEN = 5
 
 
 def start(pathogen_names):
+    maximum = None if pathogen_names else MAX_ESTIMATES_FOR_PATHOGEN
     for pathogen_name, pathogen in pathogens.pathogens.items():
         if pathogen_names and pathogen_name not in pathogen_names:
             continue
 
         print(pathogen_name)
-        skipped = 0
-        for n, estimate in enumerate(pathogen.estimate_prevalences()):
-            if n > MAX_ESTIMATES_FOR_PATHOGEN:
-                skipped += 1
-                continue
 
+        to_print = []  # key, line
+
+        for n, estimate in enumerate(pathogen.estimate_prevalences()):
             date = "no date"
             date_summary = estimate.summarize_date()
             if date_summary:
                 start_date, end_date = date_summary
+                _, end_date_month_last_day = calendar.monthrange(
+                    end_date.year, end_date.month
+                )
                 if start_date == end_date:
                     date = start_date
                 elif start_date.year != end_date.year:
@@ -30,24 +33,33 @@ def start(pathogen_names):
                     start_date.month == 1
                     and start_date.day == 1
                     and end_date.month == 12
-                    and end_date.day == 12
+                    and end_date.day == 31
                 ):
                     date = start_date.year
-                elif start_date.month != end_date.month:
-                    date = start_date.year
+                elif (
+                    start_date.month == end_date.month
+                    and start_date.day == 1
+                    and end_date.day == end_date_month_last_day
+                ):
+                    date = "%s-%s" % (
+                        start_date.year,
+                        str(start_date.month).zfill(2),
+                    )
                 else:
                     date = "%s to %s" % (start_date, end_date)
 
-            print(
-                "  %.2f per 100k (%s; %s)"
-                % (
-                    estimate.infections_per_100k,
-                    estimate.summarize_location(),
-                    date,
-                )
-            )
+            location = estimate.summarize_location()
+
+            prevalence = "%.2f per 100k" % estimate.infections_per_100k
+            line = "%s (%s; %s)" % (prevalence.rjust(18), location, date)
+            to_print.append(((location, str(date)), line))
+
+        to_print.sort()
+        for _, line in to_print[:maximum]:
+            print(line)
+        skipped = 0 if not maximum else len(to_print[maximum:])
         if skipped:
-            print("  + %s more" % skipped)
+            print(("+ %s more" % skipped).rjust(18))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously we displayed all estimates in the order they were generated, but it's easier to check that output is correct if we sort by location and then by date.

Additionally, when displaying a single pathogen, don't limit the output.  This lets us check all data for a pathogen.

```
$ ./summarize.py
sars_cov_2
     0.00 per 100k (Los Angeles, California, United States; 2020-01-20)
     0.00 per 100k (Los Angeles, California, United States; 2020-01-21)
     0.00 per 100k (Los Angeles, California, United States; 2020-01-22)
     0.10 per 100k (Los Angeles, California, United States; 2020-01-23)
     0.10 per 100k (Los Angeles, California, United States; 2020-01-24)
       + 2896 more
hiv
   230.48 per 100k (Los Angeles, California, United States; 2020)
   157.21 per 100k (United States; 2019)
hsv_2
 12100.00 per 100k (United States; 2015 to 2016)
 16980.46 per 100k (United States; 2015 to 2016)
 13077.32 per 100k (United States; 2018)
hsv_1
 98000.00 per 100k (Louisiana, United States; 2005)
 47800.00 per 100k (United States; 2015 to 2016)
 49600.00 per 100k (United States; 2015 to 2016)
norovirus
     0.82 per 100k (United States; 2012 to 2022)
hav
     0.03 per 100k (King, Washington, United States; United States; 2017)
     0.04 per 100k (King, Washington, United States; United States; 2018)
     0.15 per 100k (United States; 2018)
```