### PR TITLE
norovirus: more detailed prevalence estimate

### DIFF
--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -1,3 +1,7 @@
+from collections import Counter, defaultdict
+
+import numpy as np
+
 from pathogen_properties import *
 
 background = """Norovirus in a GI infection, mostly spread through personal
@@ -11,7 +15,7 @@ pathogen_chars = PathogenChars(
 )
 
 
-cases = IncidenceAbsolute(
+normal_year_national_cases = IncidenceAbsolute(
     annual_infections=20e6,
     confidence_interval=(19e6, 21e6),
     country="United States",
@@ -33,25 +37,94 @@ shedding_duration = SheddingDuration(
     source="https://www.mayoclinic.org/diseases-conditions/norovirus/symptoms-causes/syc-20355296",
 )
 
-rothman_period_outbreaks = Number(
-    number=13 / 5,  # 13 outbreaks over 5 months
-    country="United States",
-    source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
-    start_date="2020-08-01",
-    end_date="2020-12-31",
-)
-normal_year_outbreaks = Number(
-    number=1246 / 12,  # 1246 outbreaks over one year
-    country="United States",
-    source="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html",
-    start_date="2012",
-    end_date="2022",
-)
+
+def days_in_month(date):
+    _, last_day = calendar.monthrange(date.year, date.month)
+    return last_day
 
 
 def estimate_prevalences():
-    return [
-        cases.to_rate(us_population)
-        .to_prevalence(shedding_duration)
-        .scale(rothman_period_outbreaks.per(normal_year_outbreaks))
-    ]
+    us_outbreaks = Counter()  # date -> count
+    ca_outbreaks = Counter()  # date -> count
+
+    prevalences = []
+
+    # Downloaded from https://wwwn.cdc.gov/norsdashboard/ 2023-04-28.
+    with open(prevalence_data_filename("cdc-nors-outbreak-data.tsv")) as inf:
+        cols = None
+        for line in inf:
+            row = line.strip().split("\t")
+            if not cols:
+                cols = row
+                continue
+
+            year = int(row[cols.index("Year")])
+            month = int(row[cols.index("Month")])
+            state = row[cols.index("State")]
+            etiology = row[cols.index("Etiology")]
+            genotype = row[cols.index("Serotype or Genotype")]
+            if "Norovirus" not in etiology:
+                continue
+
+            date = year, month
+
+            us_outbreaks[date] += 1
+            if state == "California":
+                ca_outbreaks[date] += 1
+
+    normal_year_national_prevalence = normal_year_national_cases.to_rate(
+        us_population
+    ).to_prevalence(shedding_duration)
+
+    total_us_outbreaks = 0
+    total_ca_outbreaks = 0
+    days_considered = 0
+    for year in range(2012, 2020):
+        for month in range(1, 13):
+            total_us_outbreaks += us_outbreaks[year, month]
+            total_ca_outbreaks += ca_outbreaks[year, month]
+            days_considered += days_in_month(datetime.date(year, month, 1))
+    normal_us_average_daily_outbreaks = total_us_outbreaks / days_considered
+    normal_ca_average_daily_outbreaks = total_ca_outbreaks / days_considered
+
+    for target_year in range(2012, 2022):
+        for target_month in range(1, 13):
+            target_date = "%s-%s" % (target_year, str(target_month).zfill(2))
+
+            target_us_daily_outbreaks = us_outbreaks[
+                target_year, target_month
+            ] / days_in_month(datetime.date(target_year, target_month, 1))
+            target_ca_daily_outbreaks = ca_outbreaks[
+                target_year, target_month
+            ] / days_in_month(datetime.date(target_year, target_month, 1))
+
+            prevalences.append(
+                normal_year_national_prevalence.scale(
+                    Scalar(
+                        scalar=target_us_daily_outbreaks
+                        / normal_us_average_daily_outbreaks,
+                        country="United States",
+                        state="California",
+                        date=target_date,
+                        source="https://wwwn.cdc.gov/norsdashboard/",
+                    )
+                ).target(country="United States", date=target_date)
+            )
+
+            prevalences.append(
+                normal_year_national_prevalence.scale(
+                    Scalar(
+                        scalar=target_ca_daily_outbreaks
+                        / normal_ca_average_daily_outbreaks,
+                        country="United States",
+                        state="California",
+                        date=target_date,
+                        source="https://wwwn.cdc.gov/norsdashboard/",
+                    )
+                ).target(
+                    country="United States",
+                    state="California",
+                    date=target_date,
+                )
+            )
+    return prevalences


### PR DESCRIPTION
Previously I did some manual calculations to see how the Rothman period compared to normal, but this throws away a lot of data that could be useful in modeling.  Now I generate two estimates for every month, one using national outbreaks and one using CA-only outbreaks.

I'm not sure we actually want the CA-only ones, though?  They're kind of noisy, and do we expect LA county to follow CA-overall much more closely than national overall?

Before we were estimating 0.82 per 100k for the Rothman data.  With this PR we estimate:

```
National:
  2020-08 | 0.33
  2020-09 | 0.51
  2020-10 | 0.66
  2020-11 | 0.85
  2020-12 | 0.98
  2021-01 | 4.92

CA:
  2020-08 | 0
  2020-09 | 0
  2020-10 | 9.45
  2020-11 | 0
  2020-12 | 0
  2021-01 | 0
```

The CA noise is that we have a single outbreak in October 2020, and that's enough to move our estimate a lot.