### PR TITLE
Use separate prevalence estimates for each sample

### DIFF
--- a/fit_covid.py
+++ b/fit_covid.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import stats
 from fit_rothman import per100k_to_per100, print_summary
-from mgs import MGSData, BioProject
+from mgs import BioProject, MGSData
 from pathogens import pathogens
 
 plant_counties = {
@@ -44,7 +44,6 @@ if __name__ == "__main__":
         try:
             county = plant_counties[attrs.fine_location]
         except KeyError:
-            print(f"Plant {attrs.fine_location} not found")
             prevalence_per100k[i] = np.nan
         else:
             prevalence_per100k[i] = prevalence_by_loc_date[
@@ -58,7 +57,8 @@ if __name__ == "__main__":
     naive_ra_per100 = per100k_to_per100 * stats.naive_relative_abundance(
         virus_reads,
         all_reads,
-        np.mean(prevalence_per100k),
+        # Stop mypy from being persnickety while I sort out numpy annotations
+        float(np.mean(prevalence_per100k)),
     )
 
     fit = stats.fit_model(

--- a/fit_covid.py
+++ b/fit_covid.py
@@ -57,8 +57,7 @@ if __name__ == "__main__":
     naive_ra_per100 = per100k_to_per100 * stats.naive_relative_abundance(
         virus_reads,
         all_reads,
-        # Stop mypy from being persnickety while I sort out numpy annotations
-        float(np.mean(prevalence_per100k)),
+        np.mean(prevalence_per100k),
     )
 
     fit = stats.fit_model(

--- a/fit_covid.py
+++ b/fit_covid.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import numpy as np
+
+import stats
+from fit_rothman import per100k_to_per100, print_summary
+from mgs import MGSData, BioProject
+from pathogens import pathogens
+
+plant_counties = {
+    "HTP": "Los Angeles",
+    "SJ": "Los Angeles",
+    "JWPCP": "Los Angeles",
+    "OC": "Orange",
+    "PL": "San Diego",
+    "SB": "San Diego",
+    "NC": "San Diego",
+}
+
+if __name__ == "__main__":
+    bioproject = BioProject("PRJNA729801")  # Rothman
+
+    mgs_data = MGSData.from_repo()
+    samples = mgs_data.sample_attributes(bioproject)
+    all_reads = np.array(
+        [mgs_data.total_reads(bioproject)[s] for s in samples]
+    )
+
+    pathogen = "sars_cov_2"
+    taxid = pathogens[pathogen].pathogen_chars.taxid
+    virus_reads = np.array(
+        [mgs_data.viral_reads(bioproject, taxid)[s] for s in samples]
+    )
+
+    prevalence_by_loc_date = {}
+    for estimate in pathogens[pathogen].estimate_prevalences():
+        assert estimate.parsed_start == estimate.parsed_end
+        key = (estimate.county, estimate.parsed_start)
+        assert key not in prevalence_by_loc_date
+        prevalence_by_loc_date[key] = estimate.infections_per_100k
+
+    prevalence_per100k = np.zeros(len(samples))
+    for i, (sample, attrs) in enumerate(samples.items()):
+        assert attrs.fine_location is not None
+        try:
+            county = plant_counties[attrs.fine_location]
+        except KeyError:
+            print(f"Plant {attrs.fine_location} not found")
+            prevalence_per100k[i] = np.nan
+        else:
+            prevalence_per100k[i] = prevalence_by_loc_date[
+                (county, attrs.date)
+            ]
+
+    virus_reads = virus_reads[~np.isnan(prevalence_per100k)]
+    all_reads = all_reads[~np.isnan(prevalence_per100k)]
+    prevalence_per100k = prevalence_per100k[~np.isnan(prevalence_per100k)]
+
+    naive_ra_per100 = per100k_to_per100 * stats.naive_relative_abundance(
+        virus_reads,
+        all_reads,
+        np.mean(prevalence_per100k),
+    )
+
+    fit = stats.fit_model(
+        num_samples=len(virus_reads),
+        viral_read_counts=virus_reads,
+        total_read_counts=all_reads,
+        mean_log_prevalence=np.log(prevalence_per100k),
+        std_log_prevalence=0.5,
+        random_seed=1,
+    )
+    # TODO: Wrap the model fit so that we aren't exposed to stan variables
+    model_ra_per100 = per100k_to_per100 * np.exp(fit["b"])
+    print_summary(pathogen, naive_ra_per100, model_ra_per100)

--- a/fit_rothman.py
+++ b/fit_rothman.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from textwrap import dedent
 
-import numpy as np  # type: ignore
+import numpy as np
 
 import stats
 from mgs import BioProject, MGSData

--- a/stats.py
+++ b/stats.py
@@ -14,20 +14,20 @@ data {
   int<lower=1> J;               // number of samples
   array[J] int<lower=0> y;      // reads mapped to virus
   vector[J] n;                  // total reads
-  real mu;                      // mean log prevalence
+  vector[J] mu;                 // mean log prevalence
   real<lower=0>  sigma;         // std log prevalence
 }
 parameters {
   real b;                 // log conversion factor
   real<lower=0> phi;      // inverse overdispersion
-  real theta;             // true log prevalence
+  vector[J] theta;        // true log prevalence
 }
 model {
   b ~ normal(0, 10);
   phi ~ gamma(2, 2);
 
   theta ~ normal(mu, sigma);
-  y ~ neg_binomial_2(exp(b + theta) * n, phi);
+  y ~ neg_binomial_2(exp(b + theta) .* n, phi);
 }
 """
 

--- a/stats.py
+++ b/stats.py
@@ -1,20 +1,15 @@
-from typing import TypeVar
-
-import numpy as np  # type: ignore
+import numpy as np
+import numpy.typing as npt
 import stan  # type: ignore
-
-T = TypeVar("T")
-# TODO: Specify the dtype of ndarray
-ArrayLike = list[T] | np.ndarray
 
 
 def naive_relative_abundance(
-    virus_counts: ArrayLike[int],
-    all_counts: ArrayLike[int],
-    prev_per_100k: float,
+    virus_counts: npt.ArrayLike,
+    all_counts: npt.ArrayLike,
+    prev_per_100k: np.float_,
 ) -> float:
-    total_virus = sum(virus_counts)
-    total_counts = sum(all_counts)
+    total_virus = np.sum(virus_counts)
+    total_counts = np.sum(all_counts)
     return total_virus / total_counts / prev_per_100k
 
 
@@ -44,17 +39,16 @@ model {
 # TODO: Log stan output rather than writing to stderr
 def fit_model(
     num_samples: int,
-    viral_read_counts: ArrayLike[int],
-    total_read_counts: ArrayLike[int],
-    mean_log_prevalence: float | ArrayLike[float],
+    viral_read_counts: npt.ArrayLike,
+    total_read_counts: npt.ArrayLike,
+    mean_log_prevalence: npt.ArrayLike,
     std_log_prevalence: float,
     random_seed: int,
 ) -> stan.fit.Fit:
-    mu: ArrayLike[float]
     if isinstance(mean_log_prevalence, float):
-        mu = num_samples * [mean_log_prevalence]
+        mu = np.ones(num_samples) * mean_log_prevalence
     else:
-        mu = mean_log_prevalence
+        mu = np.array(mean_log_prevalence)
     data = {
         "J": num_samples,
         "y": viral_read_counts,


### PR DESCRIPTION
Resolves #46. Changes the statistical model to have a separate true prevalence parameter for each sample. At the moment they are independent, but future updates should allow for correlations. The provided estimated mean log prevalence can be either a scalar or a vector. If a scalar, each sample has the same prior mean. If a vector, each sample has the corresponding prior mean.

Fitting to the Rothman SARS-CoV-2 data with per-sample prevalence estimates:
```
> ./fit_covid.py 2> /dev/null

----------------------------------------------
sars_cov_2 relative abundance at 1% prevalence
----------------------------------------------
Naive estimate:
3.4e-07
Posterior arithmetic mean:
1.2e-07
Posterior geometric mean:
1.2e-07
Posterior quantiles:
     5%        25%        50%        75%        95%
8.0e-08    9.9e-08    1.1e-07    1.3e-07    1.7e-07
```

Fitting to all viruses with only a single mean prevalence estimate. Note that these results are different to #44 because the model has changed:
```
>  ./fit_rothman.py 2> /dev/null

----------------------------------------------
sars_cov_2 relative abundance at 1% prevalence
----------------------------------------------
Naive estimate:
2.9e-07
Posterior arithmetic mean:
1.2e-07
Posterior geometric mean:
1.1e-07
Posterior quantiles:
     5%        25%        50%        75%        95%
6.6e-08    8.9e-08    1.1e-07    1.4e-07    2.1e-07


---------------------------------------
hiv relative abundance at 1% prevalence
---------------------------------------
Naive estimate:
7.8e-09
Posterior arithmetic mean:
6.9e-09
Posterior geometric mean:
4.1e-09
Posterior quantiles:
     5%        25%        50%        75%        95%
5.4e-10    2.2e-09    4.9e-09    9.0e-09    2.0e-08


-----------------------------------------
hsv_2 relative abundance at 1% prevalence
-----------------------------------------
Naive estimate:
0.0e+00
Posterior arithmetic mean:
2.4e-11
Posterior geometric mean:
3.7e-12
Posterior quantiles:
     5%        25%        50%        75%        95%
1.1e-14    9.6e-13    7.2e-12    2.8e-11    1.0e-10


-----------------------------------------
hsv_1 relative abundance at 1% prevalence
-----------------------------------------
Naive estimate:
9.5e-10
Posterior arithmetic mean:
5.8e-10
Posterior geometric mean:
5.6e-10
Posterior quantiles:
     5%        25%        50%        75%        95%
3.6e-10    4.6e-10    5.5e-10    6.7e-10    8.7e-10


---------------------------------------------
norovirus relative abundance at 1% prevalence
---------------------------------------------
Naive estimate:
3.0e-03
Posterior arithmetic mean:
1.8e-03
Posterior geometric mean:
1.7e-03
Posterior quantiles:
     5%        25%        50%        75%        95%
1.2e-03    1.5e-03    1.7e-03    2.0e-03    2.6e-03


---------------------------------------
hav relative abundance at 1% prevalence
---------------------------------------
Naive estimate:
0.0e+00
Posterior arithmetic mean:
3.1e-06
Posterior geometric mean:
1.9e-07
Posterior quantiles:
     5%        25%        50%        75%        95%
1.0e-10    3.2e-08    5.0e-07    2.9e-06    1.5e-05
```