### PR TITLE
Update MGS sample metadata

### DIFF
--- a/fit_covid.py
+++ b/fit_covid.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import stats
 from fit_rothman import per100k_to_per100, print_summary
-from mgs import BioProject, MGSData
+from mgs import BioProject, Enrichment, MGSData
 from pathogens import pathogens
 
 plant_counties = {
@@ -20,7 +20,9 @@ if __name__ == "__main__":
     bioproject = BioProject("PRJNA729801")  # Rothman
 
     mgs_data = MGSData.from_repo()
-    samples = mgs_data.sample_attributes(bioproject)
+    samples = mgs_data.sample_attributes(
+        bioproject, enrichment=Enrichment.VIRAL
+    )
     all_reads = np.array(
         [mgs_data.total_reads(bioproject)[s] for s in samples]
     )

--- a/fit_covid.py
+++ b/fit_covid.py
@@ -6,16 +6,6 @@ from fit_rothman import per100k_to_per100, print_summary
 from mgs import BioProject, Enrichment, MGSData
 from pathogens import pathogens
 
-plant_counties = {
-    "HTP": "Los Angeles",
-    "SJ": "Los Angeles",
-    "JWPCP": "Los Angeles",
-    "OC": "Orange",
-    "PL": "San Diego",
-    "SB": "San Diego",
-    "NC": "San Diego",
-}
-
 if __name__ == "__main__":
     bioproject = BioProject("PRJNA729801")  # Rothman
 
@@ -43,14 +33,10 @@ if __name__ == "__main__":
     prevalence_per100k = np.zeros(len(samples))
     for i, (sample, attrs) in enumerate(samples.items()):
         assert attrs.fine_location is not None
-        try:
-            county = plant_counties[attrs.fine_location]
-        except KeyError:
-            prevalence_per100k[i] = np.nan
-        else:
-            prevalence_per100k[i] = prevalence_by_loc_date[
-                (county, attrs.date)
-            ]
+        assert attrs.county is not None
+        prevalence_per100k[i] = prevalence_by_loc_date[
+            (attrs.county, attrs.date)
+        ]
 
     virus_reads = virus_reads[~np.isnan(prevalence_per100k)]
     all_reads = all_reads[~np.isnan(prevalence_per100k)]

--- a/fit_rothman.py
+++ b/fit_rothman.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import numpy as np
 
 import stats
-from mgs import BioProject, MGSData
+from mgs import BioProject, Enrichment, MGSData
 from pathogens import pathogens
 
 
@@ -43,7 +43,9 @@ if __name__ == "__main__":
     bioproject = BioProject("PRJNA729801")  # Rothman
 
     mgs_data = MGSData.from_repo()
-    samples = mgs_data.sample_attributes(bioproject).keys()
+    samples = mgs_data.sample_attributes(
+        bioproject, enrichment=Enrichment.VIRAL
+    ).keys()
     all_reads = [mgs_data.total_reads(bioproject)[s] for s in samples]
 
     for pathogen_name, pathogen in pathogens.items():

--- a/get_rothman_virus_counts.py
+++ b/get_rothman_virus_counts.py
@@ -6,7 +6,9 @@ from pathogens import pathogens
 if __name__ == "__main__":
     bioproject = mgs.BioProject("PRJNA729801")  # Rothman
     mgs_data = mgs.MGSData.from_repo()
-    samples = mgs_data.sample_attributes(bioproject)
+    samples = mgs_data.sample_attributes(
+        bioproject, enrichment=mgs.Enrichment.VIRAL
+    )
 
     fine_locs = set(attribs.fine_location for _, attribs in samples.items())
 


### PR DESCRIPTION
Resolves #55. Read the new `enrichment` and `county` fields added to the sample metadata and use them to filter and subset the data where appropriate.

The changes to the metadata give us a county for `ESC` and merge `JW` into `JWPCP` so the covid fits are slightly changed. They are now:

```
$ ./fit_covid.py 2> /dev/null

----------------------------------------------
sars_cov_2 relative abundance at 1% prevalence
----------------------------------------------
Naive estimate:
3.3e-07
Posterior arithmetic mean:
1.2e-07
Posterior geometric mean:
1.2e-07
Posterior quantiles:
     5%        25%        50%        75%        95%
8.3e-08    1.0e-07    1.2e-07    1.4e-07    1.7e-07
```