### PR TITLE
Norovirus: generate estimates for 2020 and 2021

### DIFF
--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -184,6 +184,7 @@ def determine_average_daily_outbreaks(us_outbreaks: monthwise_count) -> float:
 #  * Pre-covid
 HISTORY_START = 2012
 COVID_START = 2020
+DATA_END = 2022
 
 
 def estimate_prevalences():
@@ -203,7 +204,7 @@ def estimate_prevalences():
 
     us_daily_outbreaks = to_daily_counts(us_outbreaks)
 
-    for year in range(HISTORY_START, COVID_START):
+    for year in range(HISTORY_START, DATA_END):
         for month in range(1, 13):
             target_date = f"{year}-{month:02d}"
 


### PR DESCRIPTION
I accidentally set the end date to early, and we weren't generating estimates for 2020 or 2021.  Previously:

```
$ ./summarize.py norovirus | tail
    18.07 per 100k (United States; 2019-09)
     1.46 per 100k (United States; 2019-10; 122928)
    16.03 per 100k (United States; 2019-10; 122929)
    17.48 per 100k (United States; 2019-10)
     4.47 per 100k (United States; 2019-11; 122928)
    34.45 per 100k (United States; 2019-11; 122929)
    38.91 per 100k (United States; 2019-11)
     8.34 per 100k (United States; 2019-12; 122928)
    64.67 per 100k (United States; 2019-12; 122929)
    73.01 per 100k (United States; 2019-12)
```

Now:

```
$ ./summarize.py norovirus | tail
     7.35 per 100k (United States; 2021-09)
     1.28 per 100k (United States; 2021-10; 122928)
     6.40 per 100k (United States; 2021-10; 122929)
     7.69 per 100k (United States; 2021-10)
     2.27 per 100k (United States; 2021-11; 122928)
     9.64 per 100k (United States; 2021-11; 122929)
    11.91 per 100k (United States; 2021-11)
     4.28 per 100k (United States; 2021-12; 122928)
    16.28 per 100k (United States; 2021-12; 122929)
    20.56 per 100k (United States; 2021-12)
```