### PR TITLE
Covid in Ohio: add county-specific estimates

### DIFF
--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -65,11 +65,14 @@ def estimate_prevalences():
         prevalence_data_filename("time_series_covid19_confirmed_US.csv")
     ) as inf:
         for row in csv.reader(inf):
-            county = row[5]
+            truncated_county = row[5]
             state = row[6]
 
-            full_county = "%s County" % county
-            county_state = "%s, %s" % (full_county, state)
+            # The time series data names counties like "Franklin", but the full
+            # name the census uses is "Franklin County".  Use the full names
+            # for consistency.
+            county = "%s County" % truncated_county
+            county_state = "%s, %s" % (county, state)
 
             if county_state not in target_counties:
                 continue
@@ -116,14 +119,14 @@ def estimate_prevalences():
                     annual_infections=annual_infections,
                     country="United States",
                     state=state,
-                    county=full_county,
+                    county=county,
                     date=date.isoformat(),
                 )
                 estimates.append(
                     (
                         cases.to_rate(
                             us_population(
-                                county=full_county, state=state, year=date.year
+                                county=county, state=state, year=date.year
                             )
                         ).to_prevalence(shedding_duration)
                         * underreporting

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -120,7 +120,12 @@ def estimate_prevalences():
                             )
                         ).to_prevalence(shedding_duration)
                         * underreporting
-                    ).target(date=date.isoformat())
+                    ).target(
+                        country="United States",
+                        state=state,
+                        county=county,
+                        date=date.isoformat(),
+                    )
                 )
 
     for date, annual_infections in ohio_totals.items():

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -87,16 +87,88 @@ county_populations = {
         tag="San Francisco 2020",
         source="https://www.census.gov/quickfacts/sanfranciscocountycalifornia",
     ),
+    ("Franklin", "Ohio"): Population(
+        people=1_323_800,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Franklin",
+        tag="Franklin 2020",
+        source="https://www.census.gov/quickfacts/franklincountyohio",
+    ),
+    ("Greene", "Ohio"): Population(
+        people=167_971,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Greene",
+        tag="Greene 2020",
+        source="https://www.census.gov/quickfacts/greenecountyohio",
+    ),
+    ("Lawrence", "Ohio"): Population(
+        people=58_236,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Lawrence",
+        tag="Lawrence 2020",
+        source="https://www.census.gov/quickfacts/lawrencecountyohio",
+    ),
+    ("Licking", "Ohio"): Population(
+        people=178_509,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Licking",
+        tag="Licking 2020",
+        source="https://www.census.gov/quickfacts/lickingcountyohio",
+    ),
+    ("Lucas", "Ohio"): Population(
+        people=431_273,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Lucas",
+        tag="Lucas 2020",
+        source="https://www.census.gov/quickfacts/lucascountyohio",
+    ),
+    ("Montogmery", "Ohio"): Population(
+        people=537_316,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Montogmery",
+        tag="Montogmery 2020",
+        source="https://www.census.gov/quickfacts/montgomerycountyohio",
+    ),
+    ("Sandusky", "Ohio"): Population(
+        people=58_900,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Sandusky",
+        tag="Sandusky 2020",
+        source="https://www.census.gov/quickfacts/sanduskycountyohio",
+    ),
+    ("Summit", "Ohio"): Population(
+        people=540_436,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Summit",
+        tag="Summit 2020",
+        source="https://www.census.gov/quickfacts/summitcountyohio",
+    ),
+    ("Trumbull", "Ohio"): Population(
+        people=202_069,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Trumbull",
+        tag="Trumbull 2020",
+        source="https://www.census.gov/quickfacts/trumbullcountyohio",
+    ),
 }
-
-ohio_population = Population(
-    people=11_799_374,
-    date="2020-04-01",
-    country="United States",
-    state="Ohio",
-    tag="Ohio 2020",
-    source="https://www.census.gov/quickfacts/OH",
-)
 
 
 def estimate_prevalences():
@@ -115,7 +187,7 @@ def estimate_prevalences():
             county = row[5]
             state = row[6]
 
-            if state != "Ohio" and (county, state) not in county_populations:
+            if (county, state) not in county_populations:
                 continue
 
             # In the tsv file, cumulative case counts start at column 11 with
@@ -143,30 +215,28 @@ def estimate_prevalences():
                 # https://www.jefftk.com/p/careful-with-trailing-averages
                 date = str(day - datetime.timedelta(days=3))
                 annual_infections = sum(latest) * 52
-                if state == "Ohio":
-                    ohio_totals[date] += annual_infections
-                else:
-                    cases = IncidenceAbsolute(
-                        annual_infections=annual_infections,
+
+                cases = IncidenceAbsolute(
+                    annual_infections=annual_infections,
+                    country="United States",
+                    state=state,
+                    county=county,
+                    date=date,
+                    tag="%s 2020" % county,
+                )
+                estimates.append(
+                    (
+                        cases.to_rate(
+                            county_populations[county, state]
+                        ).to_prevalence(shedding_duration)
+                        * underreporting
+                    ).target(
                         country="United States",
                         state=state,
                         county=county,
                         date=date,
-                        tag="%s 2020" % county,
                     )
-                    estimates.append(
-                        (
-                            cases.to_rate(
-                                county_populations[county, state]
-                            ).to_prevalence(shedding_duration)
-                            * underreporting
-                        ).target(
-                            country="United States",
-                            state=state,
-                            county=county,
-                            date=date,
-                        )
-                    )
+                )
 
     for date, annual_infections in ohio_totals.items():
         cases = IncidenceAbsolute(

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -41,14 +41,14 @@ target_counties = set(
         "Alameda County, California",
         "Marin County, California",
         "San Francisco County, California",
-        "Franklin County, Ohio"
-        "Greene County, Ohio"
-        "Lawrence County, Ohio"
-        "Licking County, Ohio"
-        "Lucas County, Ohio"
-        "Montogmery County, Ohio"
-        "Sandusky County, Ohio"
-        "Summit County, Ohio"
+        "Franklin County, Ohio",
+        "Greene County, Ohio",
+        "Lawrence County, Ohio",
+        "Licking County, Ohio",
+        "Lucas County, Ohio",
+        "Montogmery County, Ohio",
+        "Sandusky County, Ohio",
+        "Summit County, Ohio",
         "Trumbull County, Ohio",
     ]
 )

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -57,8 +57,6 @@ target_counties = set(
 def estimate_prevalences():
     estimates = []
 
-    ohio_totals = Counter()  # day -> total new cases, 7d moving average
-
     # From the COVID-19 Data Repository by the Center for Systems Science and
     # Engineering (CSSE) at Johns Hopkins University
     #
@@ -103,6 +101,15 @@ def estimate_prevalences():
                 if date.year > 2022:
                     continue
 
+                # Right now we use the same underreporting figure for both
+                # Spring/Fall 2020 and Winter 2021-2022.
+                #
+                # TODO: we can probably get a better undereporting figure for
+                # the omicron surge and this is likely too small.  The CDC 4x
+                # figure is not intended to cover this time period, this was
+                # after rapid tests were starting to be available, and omicron
+                # was relatively mild.
+
                 annual_infections = sum(latest) * 52
 
                 cases = IncidenceAbsolute(
@@ -127,29 +134,5 @@ def estimate_prevalences():
                         date=date.isoformat(),
                     )
                 )
-
-    for date, annual_infections in ohio_totals.items():
-        cases = IncidenceAbsolute(
-            annual_infections=annual_infections,
-            country="United States",
-            state="Ohio",
-            date=date.isoformat(),
-        )
-        # TODO: we can probably get a better undereporting figure for the
-        # omicron surge and this is likely too small.  The CDC 4x figure is not
-        # intended to cover this time period, this was after rapid tests were
-        # starting to be available, and omicron was relatively mild.
-        estimates.append(
-            (
-                cases.to_rate(
-                    us_population(state="Ohio", year=date.year)
-                ).to_prevalence(shedding_duration)
-                * underreporting
-            ).target(
-                country="United States",
-                state="Ohio",
-                date=date.isoformat(),
-            )
-        )
 
     return estimates

--- a/populations.py
+++ b/populations.py
@@ -2,22 +2,13 @@ from typing import Optional
 
 from pathogen_properties import Population, prevalence_data_filename
 
+location_populations: list[tuple[str, dict[int, int]]] = []
 
-def us_population(
-    year: int, county: Optional[str] = None, state: Optional[str] = None
-) -> Population:
-    if year not in [2020, 2021, 2022]:
-        raise Exception("Unsupported year: %s" % year)
-    year_column = {
-        2020: 2,
-        2021: 3,
-        2022: 4,
-    }[year]
 
-    total_people = 0
-    # All estimates are July 1st, specifically.
-    pop_date = "%s-07-01" % year
-    source = "https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html"
+def load_location_populations():
+    if location_populations:
+        return
+
     # Downloaded 2023-05-11 from
     # https://www2.census.gov/programs-surveys/popest/tables/2020-2022/counties/totals/co-est2022-pop.xlsx
     with open(prevalence_data_filename("Census-co-est2022-pop.tsv")) as inf:
@@ -27,28 +18,47 @@ def us_population(
                 continue
 
             location = bits[0]
-            people = int(bits[year_column].replace(",", ""))
+            counts = {
+                2020: int(bits[2].replace(",", "")),
+                2021: int(bits[3].replace(",", "")),
+                2022: int(bits[4].replace(",", "")),
+            }
+            location_populations.append((location, counts))
 
-            if not county and not state and location == "United States":
-                return Population(
-                    people=people,
-                    source=source,
-                    date=pop_date,
-                    country="United States",
-                )
 
-            if location == ".%s, %s" % (county, state):
-                return Population(
-                    people=people,
-                    source=source,
-                    date=pop_date,
-                    country="United States",
-                    state=state,
-                    county=county,
-                )
+def us_population(
+    year: int, county: Optional[str] = None, state: Optional[str] = None
+) -> Population:
+    if year not in [2020, 2021, 2022]:
+        raise Exception("Unsupported year: %s" % year)
 
-            if not county and location.endswith(", %s" % state):
-                total_people += people
+    total_people = 0
+    # All estimates are July 1st, specifically.
+    pop_date = "%s-07-01" % year
+    source = "https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html"
+    load_location_populations()
+    for location, counts in location_populations:
+        people = counts[year]
+        if not county and not state and location == "United States":
+            return Population(
+                people=people,
+                source=source,
+                date=pop_date,
+                country="United States",
+            )
+
+        if location == ".%s, %s" % (county, state):
+            return Population(
+                people=people,
+                source=source,
+                date=pop_date,
+                country="United States",
+                state=state,
+                county=county,
+            )
+
+        if not county and location.endswith(", %s" % state):
+            total_people += people
 
     if total_people == 0:
         raise Exception("county=%r, state=%r not found" % (county, state))


### PR DESCRIPTION
Now that we have county-level data for Spurbeck 2023, estimate covid on a per-county basis in Ohio.

Before:

```
$ ./summarize.py sars_cov_2 | grep Ohio | grep 2021-12-26
  8270.36 per 100k (Ohio, United States; 2021-12-26)
```

After:

```
$  ./summarize.py sars_cov_2 | grep Ohio | grep 2021-12-26
  9048.02 per 100k (Franklin, Ohio, United States; 2021-12-26)
  4338.53 per 100k (Greene, Ohio, United States; 2021-12-26)
  4878.58 per 100k (Lawrence, Ohio, United States; 2021-12-26)
  6463.61 per 100k (Licking, Ohio, United States; 2021-12-26)
  7128.86 per 100k (Lucas, Ohio, United States; 2021-12-26)
  5498.57 per 100k (Sandusky, Ohio, United States; 2021-12-26)
 13384.03 per 100k (Summit, Ohio, United States; 2021-12-26)
  7301.93 per 100k (Trumbull, Ohio, United States; 2021-12-26)
```