### PR TITLE
Remove the need for tag= in most cases

### DIFF
--- a/pathogens/dengue.py
+++ b/pathogens/dengue.py
@@ -1,4 +1,5 @@
 from pathogen_properties import *
+from populations import us_population
 
 background = """Dengue virus, a mosquito-borne viral infection primarily
 transmitted by the Aedes aegypti and Aedes albopictus mosquitoes, present 
@@ -19,15 +20,9 @@ california_reported_cases = IncidenceAbsolute(
     state="California",
     date="2020",
     source="https://www.cdph.ca.gov/Programs/CID/DCDC/CDPH%20Document%20Library/TravelAssociatedCasesofDengueVirusinCA.pdf",
-    tag="California-2020",
+    tag="California 2020",
 )
 
-CA_population = Population(
-    people=39_538_245,
-    tag="California-2020",
-    date="2020-04",
-    source="https://www.census.gov/quickfacts/CA",
-)
 # disease duration in days
 disease_duration = SheddingDuration(
     days=7,
@@ -37,7 +32,7 @@ disease_duration = SheddingDuration(
 
 def estimate_prevalences():
     return [
-        california_reported_cases.to_rate(CA_population).to_prevalence(
-            disease_duration
-        )
+        california_reported_cases.to_rate(
+            us_population(state="California", year=2020)
+        ).to_prevalence(disease_duration)
     ]

--- a/pathogens/dengue.py
+++ b/pathogens/dengue.py
@@ -20,7 +20,6 @@ california_reported_cases = IncidenceAbsolute(
     state="California",
     date="2020",
     source="https://www.cdph.ca.gov/Programs/CID/DCDC/CDPH%20Document%20Library/TravelAssociatedCasesofDengueVirusinCA.pdf",
-    tag="California 2020",
 )
 
 # disease duration in days

--- a/pathogens/hav.py
+++ b/pathogens/hav.py
@@ -25,7 +25,6 @@ us_incidence_absolute_2018 = IncidenceAbsolute(
     coverage_probability=0.95,
     country="United States",
     date="2018",
-    tag="us-2018",
     source="https://www.cdc.gov/hepatitis/statistics/2018surveillance/HepA.htm",
 )
 
@@ -33,7 +32,6 @@ us_population_2018 = Population(
     people=327.2 * 1e6,
     country="United States",
     date="2018",
-    tag="us-2018",
     source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
 )
 
@@ -59,9 +57,8 @@ king_county_absolute_2017 = IncidenceAbsolute(
     annual_infections=11,
     country="United States",
     state="Washington",
-    county="King",
+    county="King County",
     date="2017",
-    tag="King 2017",
     source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
 )
 
@@ -69,9 +66,8 @@ king_county_absolute_2018 = IncidenceAbsolute(
     annual_infections=14,
     country="United States",
     state="Washington",
-    county="King",
+    county="King County",
     date="2018",
-    tag="King 2018",
     source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
 )
 

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -1,4 +1,5 @@
 from pathogen_properties import *
+from populations import us_population
 
 background = """Hepatitis B is a liver infection caused by the Hepatitis B
  virus. It is transmitted through birth and contact with infected blood or
@@ -40,7 +41,7 @@ cdc_estimated_acute_2019 = IncidenceAbsolute(
     coverage_probability=0.95,
     country="United States",
     date="2019",
-    tag="us_2019",
+    tag="United States 2019",
     source="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=20%2C700%20estimated%20infections%20(95%25%20CI%3A%2011%2C800%E2%80%9350%2C800)",
     methods="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=To%20account%20for,CI%3A%2011.0%E2%80%9347.4).",
 )
@@ -59,7 +60,7 @@ estimated_chronic_us_2020 = PrevalenceAbsolute(
     active=Active.LATENT,
     country="United States",
     date="2020",
-    tag="us_2020",
+    tag="United States 2020",
     source="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Table%204.%3A%20Estimated%20prevalence%20of%20chronic%20HBV%20in%20the%20United%20Statesa",
     methods="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Panel%20members%20researched,in%20the%20US.",
 )
@@ -69,17 +70,8 @@ us_population_2019 = Population(
     people=328.2 * 1e6,
     country="United States",
     date="2019",
-    tag="us_2019",
+    tag="United States 2019",
     source="https://data.census.gov/table?q=us+population+2019&tid=ACSDP1Y2019.DP05",
-)
-
-
-us_population_2020 = Population(
-    people=331.4 * 1e6,
-    country="United States",
-    date="2020",
-    tag="us_2020",
-    source="https://data.census.gov/table?q=2020+us+population&t=Civilian+Population&tid=DECENNIALPL2020.P1",
 )
 
 
@@ -88,5 +80,5 @@ def estimate_prevalences():
         cdc_estimated_acute_2019.to_rate(us_population_2019).to_prevalence(
             dna_present_in_serum
         ),
-        estimated_chronic_us_2020.to_rate(us_population_2020),
+        estimated_chronic_us_2020.to_rate(us_population(year=2020)),
     ]

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -41,7 +41,6 @@ cdc_estimated_acute_2019 = IncidenceAbsolute(
     coverage_probability=0.95,
     country="United States",
     date="2019",
-    tag="United States 2019",
     source="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=20%2C700%20estimated%20infections%20(95%25%20CI%3A%2011%2C800%E2%80%9350%2C800)",
     methods="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=To%20account%20for,CI%3A%2011.0%E2%80%9347.4).",
 )
@@ -60,7 +59,6 @@ estimated_chronic_us_2020 = PrevalenceAbsolute(
     active=Active.LATENT,
     country="United States",
     date="2020",
-    tag="United States 2020",
     source="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Table%204.%3A%20Estimated%20prevalence%20of%20chronic%20HBV%20in%20the%20United%20Statesa",
     methods="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Panel%20members%20researched,in%20the%20US.",
 )
@@ -70,7 +68,6 @@ us_population_2019 = Population(
     people=328.2 * 1e6,
     country="United States",
     date="2019",
-    tag="United States 2019",
     source="https://data.census.gov/table?q=us+population+2019&tid=ACSDP1Y2019.DP05",
 )
 

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -1,4 +1,5 @@
 from pathogen_properties import *
+from populations import us_population
 
 background = """HIV is a sexually-transmitted retrovirus which gradually
 weakens the immune system."""
@@ -41,7 +42,7 @@ la_unsuppressed_fraction_2020 = Scalar(
     scalar=1 - 0.6,
     country="United States",
     state="California",
-    county="Los Angeles",
+    county="Los Angeles County",
     date="2020",
     source="https://web.archive.org/web/20201202004910/https://www.lacounty.hiv/",
 )
@@ -50,21 +51,11 @@ la_infected_2020 = PrevalenceAbsolute(
     infections=57_700,
     country="United States",
     state="California",
-    county="Los Angeles",
+    county="Los Angeles County",
     date="2020",
-    tag="la-2020",
+    tag="Los Angeles County, California 2020",
     active=Active.LATENT,
     source="https://web.archive.org/web/20201202004910/https://www.lacounty.hiv/",
-)
-
-la_population_2020 = Population(
-    people=10_014_009,
-    country="United States",
-    state="California",
-    county="Los Angeles",
-    date="2020-04-01",
-    tag="la-2020",
-    source="https://www.census.gov/quickfacts/losangelescountycalifornia",
 )
 
 
@@ -72,6 +63,10 @@ def estimate_prevalences():
     return [
         us_infected_2019.to_rate(us_population_2019)
         * us_unsuppressed_fraction_2019,
-        la_infected_2020.to_rate(la_population_2020)
+        la_infected_2020.to_rate(
+            us_population(
+                state="California", county="Los Angeles County", year=2020
+            )
+        )
         * la_unsuppressed_fraction_2020,
     ]

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -25,7 +25,6 @@ us_infected_2019 = PrevalenceAbsolute(
     infections=1.2e6,
     country="United States",
     date="2019",
-    tag="usa-2019",
     active=Active.LATENT,
     source="https://www.cdc.gov/hiv/library/reports/hiv-surveillance/vol-26-no-2/content/national-profile.html#:~:text=Among%20the%20estimated-,1.2%20million%20people,-living%20with%20HIV",
 )
@@ -34,7 +33,6 @@ us_population_2019 = Population(
     people=328_231_337,
     country="United States",
     date="2019-01-01",
-    tag="usa-2019",
     source="https://www.census.gov/newsroom/press-releases/2019/new-years-population.html",
 )
 
@@ -53,7 +51,6 @@ la_infected_2020 = PrevalenceAbsolute(
     state="California",
     county="Los Angeles County",
     date="2020",
-    tag="Los Angeles County, California 2020",
     active=Active.LATENT,
     source="https://web.archive.org/web/20201202004910/https://www.lacounty.hiv/",
 )

--- a/pathogens/hsv_2.py
+++ b/pathogens/hsv_2.py
@@ -33,7 +33,7 @@ cdc_2018_nhanes_estimate = PrevalenceAbsolute(
     coverage_probability=0.5,
     date="2018",
     country="United States",
-    tag="18-49yo_us_population",
+    tag="18-49yo",
     active=Active.LATENT,
     source="https://journals.lww.com/stdjournal/Fulltext/2021/04000/Estimates_of_the_Prevalence_and_Incidence_of.9.aspx#:~:text=In%202018%2C%20there,that%20are%20genital.",
     methods="https://journals.lww.com/stdjournal/Fulltext/2021/04000/Estimates_of_the_Prevalence_and_Incidence_of.9.aspx#:~:text=genital%20infections%20burden.-,METHODS,-We%20estimated%20the",
@@ -57,35 +57,35 @@ stratified_us_pop = {
         date="2018",
         country="United States",
         source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
-        tag="15-19yo_us_population",
+        tag="15-19yo",
     ),
     "20-24": Population(
         people=21_717_962,
         date="2018",
         country="United States",
         source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
-        tag="20-24yo_us_population",
+        tag="20-24yo",
     ),
     "25-34": Population(
         people=45_344_674,
         date="2018",
         country="United States",
         source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
-        tag="25-34yo_us_population",
+        tag="25-34yo",
     ),
     "35-44": Population(
         people=41_498_453,
         date="2018",
         country="United States",
         source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
-        tag="35-44yo_us_population",
+        tag="35-44yo",
     ),
     "45-54": Population(
         people=41_605_244,
         date="2018",
         country="United States",
         source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
-        tag="45-54yo_us_population",
+        tag="45-54yo",
     ),
 }
 
@@ -97,7 +97,7 @@ us_population_2018_18_to_49yo = Population(
     + stratified_us_pop["45-54"].people * 0.5,
     date="2018",
     country="United States",
-    tag="18-49yo_us_population",
+    tag="18-49yo",
     inputs=list(stratified_us_pop.values()),
 )
 

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -40,7 +40,6 @@ us_national_foodborne_cases_2006 = IncidenceAbsolute(
     confidence_interval=(3_227_078, 8_309_480),
     coverage_probability=0.9,  # credible interval
     country="United States",
-    tag="us-2006",
     date="2006",
     # "Domestically acquired foodborne, mean (90% credible interval)
     # ... 5,461,731 (3,227,078–8,309,480)"
@@ -59,7 +58,6 @@ us_population_2006 = Population(
     people=299_000_000,
     country="United States",
     date="2006",
-    tag="us-2006",
     # "all estimates were based on the US population in 2006 (299 million
     # persons)"
     source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3375761/#:~:text=population%20in%202006%20(-,299%20million%20persons,-).%20Estimates%20were%20derived",

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -90,7 +90,10 @@ def estimate_prevalences():
 
                 # centered moving average
                 # https://www.jefftk.com/p/careful-with-trailing-averages
-                date = str(day - datetime.timedelta(days=3))
+                date = day - datetime.timedelta(days=3)
+                if date.year > 2022:
+                    continue
+
                 annual_infections = sum(latest) * 52
                 if state == "Ohio":
                     ohio_totals[date] += annual_infections
@@ -99,15 +102,16 @@ def estimate_prevalences():
                         annual_infections=annual_infections,
                         country="United States",
                         state=state,
-                        county=county,
-                        date=date,
-                        tag="%s 2020" % county_state,
+                        county=full_county,
+                        date=date.isoformat(),
                     )
                     estimates.append(
                         (
                             cases.to_rate(
                                 us_population(
-                                    county=full_county, state=state, year=2020
+                                    county=full_county,
+                                    state=state,
+                                    year=date.year,
                                 )
                             ).to_prevalence(shedding_duration)
                             * underreporting
@@ -115,7 +119,7 @@ def estimate_prevalences():
                             country="United States",
                             state=state,
                             county=county,
-                            date=date,
+                            date=date.isoformat(),
                         )
                     )
 
@@ -124,8 +128,7 @@ def estimate_prevalences():
             annual_infections=annual_infections,
             country="United States",
             state="Ohio",
-            date=date,
-            tag="Ohio 2020",
+            date=date.isoformat(),
         )
         # TODO: we can probably get a better undereporting figure for the
         # omicron surge and this is likely too small.  The CDC 4x figure is not
@@ -134,13 +137,13 @@ def estimate_prevalences():
         estimates.append(
             (
                 cases.to_rate(
-                    us_population(state="Ohio", year=2020)
+                    us_population(state="Ohio", year=date.year)
                 ).to_prevalence(shedding_duration)
                 * underreporting
             ).target(
                 country="United States",
                 state="Ohio",
-                date=date,
+                date=date.isoformat(),
             )
         )
 

--- a/pathogens/west_nile_virus.py
+++ b/pathogens/west_nile_virus.py
@@ -20,7 +20,9 @@ pathogen_chars = PathogenChars(
 
 LA_county_cases_in_2020 = IncidenceAbsolute(
     annual_infections=90,
-    tag="Los Angeles County, California 2020",
+    country="United States",
+    state="California",
+    county="Los Angeles County",
     date="2020",
     source="https://westnile.ca.gov/pdfs/VBDSAnnualReport20.pdf#?page=23",
 )

--- a/pathogens/west_nile_virus.py
+++ b/pathogens/west_nile_virus.py
@@ -1,4 +1,5 @@
 from pathogen_properties import *
+from populations import us_population
 
 # TODO: We should add a CI once we know how to get from tested individuals to
 # CI
@@ -19,18 +20,10 @@ pathogen_chars = PathogenChars(
 
 LA_county_cases_in_2020 = IncidenceAbsolute(
     annual_infections=90,
-    tag="LA-2020",
+    tag="Los Angeles County, California 2020",
     date="2020",
     source="https://westnile.ca.gov/pdfs/VBDSAnnualReport20.pdf#?page=23",
 )
-
-LA_county_population = Population(
-    people=10_014_009,
-    date="2020",
-    tag="LA-2020",
-    source="https://www.census.gov/quickfacts/fact/table/losangelescountycalifornia,CA/POP010220#POP010220",
-)
-
 
 west_nile_duration = SheddingDuration(
     # Symptoms last for 3-6 days usually, but sometimes for up to a month. I'm
@@ -51,8 +44,10 @@ asymptomatic_multiplier = Scalar(
 
 def estimate_prevalences():
     return [
-        LA_county_cases_in_2020.to_rate(LA_county_population).to_prevalence(
-            west_nile_duration
-        )
+        LA_county_cases_in_2020.to_rate(
+            us_population(
+                county="Los Angeles County", state="California", year=2020
+            )
+        ).to_prevalence(west_nile_duration)
         * asymptomatic_multiplier
     ]

--- a/populations.py
+++ b/populations.py
@@ -35,7 +35,6 @@ def us_population(
                     source=source,
                     date=pop_date,
                     country="United States",
-                    tag="%s %s" % (location, year),
                 )
 
             if location == ".%s, %s" % (county, state):
@@ -46,7 +45,6 @@ def us_population(
                     country="United States",
                     state=state,
                     county=county,
-                    tag="%s, %s %s" % (county, state, year),
                 )
 
             if not county and location.endswith(", %s" % state):
@@ -62,5 +60,4 @@ def us_population(
         date=pop_date,
         country="United States",
         state=state,
-        tag="%s %s" % (state, year),
     )

--- a/populations.py
+++ b/populations.py
@@ -1,0 +1,66 @@
+from typing import Optional
+
+from pathogen_properties import Population, prevalence_data_filename
+
+
+def us_population(
+    year: int, county: Optional[str] = None, state: Optional[str] = None
+) -> Population:
+    if year not in [2020, 2021, 2022]:
+        raise Exception("Unsupported year: %s" % year)
+    year_column = {
+        2020: 2,
+        2021: 3,
+        2022: 4,
+    }[year]
+
+    total_people = 0
+    # All estimates are July 1st, specifically.
+    pop_date = "%s-07-01" % year
+    source = "https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html"
+    # Downloaded 2023-05-11 from
+    # https://www2.census.gov/programs-surveys/popest/tables/2020-2022/counties/totals/co-est2022-pop.xlsx
+    with open(prevalence_data_filename("Census-co-est2022-pop.tsv")) as inf:
+        for line in inf:
+            bits = line.strip().split("\t")
+            if len(bits) != 5:
+                continue
+
+            location = bits[0]
+            people = int(bits[year_column].replace(",", ""))
+
+            if not county and not state and location == "United States":
+                return Population(
+                    people=people,
+                    source=source,
+                    date=pop_date,
+                    country="United States",
+                    tag="%s %s" % (location, year),
+                )
+
+            if location == ".%s, %s" % (county, state):
+                return Population(
+                    people=people,
+                    source=source,
+                    date=pop_date,
+                    country="United States",
+                    state=state,
+                    county=county,
+                    tag="%s, %s %s" % (county, state, year),
+                )
+
+            if not county and location.endswith(", %s" % state):
+                total_people += people
+
+    if total_people == 0:
+        raise Exception("county=%r, state=%r not found" % (county, state))
+
+    # The only case where we total up is to get state populations.
+    return Population(
+        people=total_people,
+        source=source,
+        date=pop_date,
+        country="United States",
+        state=state,
+        tag="%s %s" % (state, year),
+    )

--- a/prevalence-data/Census-co-est2022-pop.tsv
+++ b/prevalence-data/Census-co-est2022-pop.tsv
@@ -1,0 +1,3154 @@
+table with row headers in column A and column headers in rows 3 through 4 (leading dots indicate sub-parts)				
+Annual Estimates of the Resident Population for Counties in the United States: April 1, 2020 to July 1, 2022				
+Geographic Area	April 1, 2020 Estimates Base	Population Estimate (as of July 1)		
+		2020	2021	2022
+United States	331,449,520	331,511,512	332,031,554	333,287,557
+.Autauga County, Alabama	58,802	58,902	59,210	59,759
+.Baldwin County, Alabama	231,761	233,219	239,361	246,435
+.Barbour County, Alabama	25,224	24,960	24,539	24,706
+.Bibb County, Alabama	22,300	22,183	22,370	22,005
+.Blount County, Alabama	59,130	59,102	59,085	59,512
+.Bullock County, Alabama	10,362	10,296	10,280	10,202
+.Butler County, Alabama	19,055	19,031	18,855	18,650
+.Calhoun County, Alabama	116,444	116,239	115,677	115,788
+.Chambers County, Alabama	34,774	34,645	34,446	34,088
+.Cherokee County, Alabama	24,979	24,972	25,026	25,302
+.Chilton County, Alabama	45,009	45,051	45,259	45,884
+.Choctaw County, Alabama	12,663	12,619	12,549	12,439
+.Clarke County, Alabama	23,087	22,981	22,715	22,515
+.Clay County, Alabama	14,237	14,211	14,190	14,198
+.Cleburne County, Alabama	15,057	15,063	15,148	15,346
+.Coffee County, Alabama	53,460	53,547	54,171	54,805
+.Colbert County, Alabama	57,232	57,299	57,619	58,033
+.Conecuh County, Alabama	11,597	11,553	11,320	11,206
+.Coosa County, Alabama	10,382	10,341	10,366	10,166
+.Covington County, Alabama	37,567	37,507	37,542	37,602
+.Crenshaw County, Alabama	13,197	13,165	13,056	13,025
+.Cullman County, Alabama	87,857	88,131	89,618	90,665
+.Dale County, Alabama	49,319	49,253	49,412	49,544
+.Dallas County, Alabama	38,463	38,174	37,565	36,767
+.DeKalb County, Alabama	71,611	71,648	71,829	71,998
+.Elmore County, Alabama	87,974	87,853	88,737	89,563
+.Escambia County, Alabama	36,767	36,680	36,658	36,666
+.Etowah County, Alabama	103,441	103,447	103,139	103,088
+.Fayette County, Alabama	16,326	16,330	16,155	16,118
+.Franklin County, Alabama	32,113	32,075	31,996	31,932
+.Geneva County, Alabama	26,660	26,696	26,667	26,783
+.Greene County, Alabama	7,734	7,702	7,592	7,422
+.Hale County, Alabama	14,786	14,768	14,737	14,595
+.Henry County, Alabama	17,148	17,175	17,434	17,655
+.Houston County, Alabama	107,204	107,286	107,453	108,079
+.Jackson County, Alabama	52,582	52,545	52,694	52,891
+.Jefferson County, Alabama	674,355	674,675	669,997	665,409
+.Lamar County, Alabama	13,976	13,956	13,740	13,705
+.Lauderdale County, Alabama	93,565	94,025	94,862	95,878
+.Lawrence County, Alabama	33,077	33,089	33,123	33,214
+.Lee County, Alabama	174,244	174,742	177,655	180,773
+.Limestone County, Alabama	103,563	104,190	107,381	110,900
+.Lowndes County, Alabama	10,310	10,273	9,926	9,777
+.Macon County, Alabama	19,534	19,473	18,906	18,516
+.Madison County, Alabama	388,160	390,502	396,593	403,565
+.Marengo County, Alabama	19,324	19,266	18,961	18,745
+.Marion County, Alabama	29,341	29,166	29,006	29,156
+.Marshall County, Alabama	97,611	97,696	98,316	99,423
+.Mobile County, Alabama	414,812	414,353	413,017	411,411
+.Monroe County, Alabama	19,770	19,704	19,557	19,404
+.Montgomery County, Alabama	228,948	228,322	226,953	226,361
+.Morgan County, Alabama	123,421	123,288	123,403	124,211
+.Perry County, Alabama	8,515	8,458	8,317	8,035
+.Pickens County, Alabama	19,124	18,922	18,615	18,697
+.Pike County, Alabama	33,008	32,906	32,740	33,014
+.Randolph County, Alabama	21,970	22,092	22,199	22,479
+.Russell County, Alabama	59,187	59,259	58,668	58,555
+.St. Clair County, Alabama	91,471	91,652	92,903	93,932
+.Shelby County, Alabama	223,034	223,881	227,428	230,115
+.Sumter County, Alabama	12,348	12,196	11,961	11,853
+.Talladega County, Alabama	82,152	81,428	80,483	80,704
+.Tallapoosa County, Alabama	41,316	41,286	41,132	40,977
+.Tuscaloosa County, Alabama	227,041	231,534	235,668	236,780
+.Walker County, Alabama	65,342	65,132	64,629	64,339
+.Washington County, Alabama	15,388	15,327	15,234	15,122
+.Wilcox County, Alabama	10,601	10,432	10,331	10,059
+.Winston County, Alabama	23,544	23,488	23,672	23,755
+.Aleutians East Borough, Alaska	3,419	3,425	3,424	3,398
+.Aleutians West Census Area, Alaska	5,232	5,222	5,155	5,122
+.Anchorage Municipality, Alaska	291,244	290,866	288,702	287,145
+.Bethel Census Area, Alaska	18,670	18,673	18,599	18,257
+.Bristol Bay Borough, Alaska	843	829	841	865
+.Chugach Census Area, Alaska	7,097	7,077	6,943	6,874
+.Copper River Census Area, Alaska	2,618	2,616	2,611	2,589
+.Denali Borough, Alaska	1,624	1,614	1,594	1,585
+.Dillingham Census Area, Alaska	4,853	4,835	4,774	4,723
+.Fairbanks North Star Borough, Alaska	95,657	95,328	95,528	95,356
+.Haines Borough, Alaska	2,080	2,086	2,074	2,056
+.Hoonah-Angoon Census Area, Alaska	2,364	2,362	2,339	2,287
+.Juneau City and Borough, Alaska	32,255	32,202	31,965	31,685
+.Kenai Peninsula Borough, Alaska	58,789	58,927	59,851	60,690
+.Ketchikan Gateway Borough, Alaska	13,957	13,918	13,810	13,741
+.Kodiak Island Borough, Alaska	13,101	13,047	12,864	12,720
+.Kusilvak Census Area, Alaska	8,372	8,373	8,398	8,278
+.Lake and Peninsula Borough, Alaska	1,476	1,452	1,419	1,381
+.Matanuska-Susitna Borough, Alaska	107,082	107,515	111,059	113,325
+.Nome Census Area, Alaska	10,049	10,028	9,908	9,835
+.North Slope Borough, Alaska	11,030	11,002	11,011	10,805
+.Northwest Arctic Borough, Alaska	7,790	7,790	7,560	7,423
+.Petersburg Borough, Alaska	3,399	3,405	3,373	3,360
+.Prince of Wales-Hyder Census Area, Alaska	5,753	5,739	5,734	5,650
+.Sitka City and Borough, Alaska	8,448	8,425	8,410	8,382
+.Skagway Municipality, Alaska	1,242	1,240	1,142	1,081
+.Southeast Fairbanks Census Area, Alaska	6,805	6,820	7,005	7,021
+.Wrangell City and Borough, Alaska	2,126	2,127	2,100	2,070
+.Yakutat City and Borough, Alaska	664	684	709	700
+.Yukon-Koyukuk Census Area, Alaska	5,339	5,296	5,280	5,179
+.Apache County, Arizona	66,024	65,911	65,385	65,432
+.Cochise County, Arizona	125,448	125,522	125,763	125,663
+.Coconino County, Arizona	145,100	145,180	142,780	144,060
+.Gila County, Arizona	53,273	53,351	53,521	53,922
+.Graham County, Arizona	38,533	38,638	38,882	38,779
+.Greenlee County, Arizona	9,561	9,526	9,377	9,302
+.La Paz County, Arizona	16,555	16,575	16,391	16,506
+.Maricopa County, Arizona	4,420,574	4,440,232	4,494,693	4,551,524
+.Mohave County, Arizona	213,269	214,176	216,957	220,816
+.Navajo County, Arizona	106,716	106,762	107,621	108,650
+.Pima County, Arizona	1,043,434	1,045,175	1,048,895	1,057,597
+.Pinal County, Arizona	425,257	429,446	448,144	464,154
+.Santa Cruz County, Arizona	47,665	47,705	48,034	48,759
+.Yavapai County, Arizona	236,218	237,216	242,193	246,191
+.Yuma County, Arizona	203,880	204,528	206,241	207,842
+.Arkansas County, Arkansas	17,150	17,107	16,683	16,512
+.Ashley County, Arkansas	19,064	18,962	18,649	18,354
+.Baxter County, Arkansas	41,633	41,687	42,171	42,435
+.Benton County, Arkansas	284,329	286,586	294,337	302,863
+.Boone County, Arkansas	37,372	37,383	37,890	38,284
+.Bradley County, Arkansas	10,540	10,488	10,332	10,135
+.Calhoun County, Arkansas	4,742	4,738	4,737	4,695
+.Carroll County, Arkansas	28,260	28,242	28,480	28,742
+.Chicot County, Arkansas	10,212	10,157	10,071	9,873
+.Clark County, Arkansas	21,447	21,387	21,217	21,250
+.Clay County, Arkansas	14,548	14,528	14,370	14,265
+.Cleburne County, Arkansas	24,705	24,696	25,044	25,284
+.Cleveland County, Arkansas	7,548	7,550	7,490	7,467
+.Columbia County, Arkansas	22,798	22,742	22,510	22,216
+.Conway County, Arkansas	20,709	20,729	20,911	21,046
+.Craighead County, Arkansas	111,233	111,603	111,788	113,017
+.Crawford County, Arkansas	60,130	60,147	60,423	61,075
+.Crittenden County, Arkansas	48,169	48,086	47,475	47,061
+.Cross County, Arkansas	16,830	16,796	16,693	16,601
+.Dallas County, Arkansas	6,479	6,442	6,306	6,191
+.Desha County, Arkansas	11,395	11,320	11,050	10,771
+.Drew County, Arkansas	17,348	17,314	17,070	16,911
+.Faulkner County, Arkansas	123,498	123,811	125,645	127,665
+.Franklin County, Arkansas	17,101	17,135	17,166	17,271
+.Fulton County, Arkansas	12,077	12,057	12,156	12,382
+.Garland County, Arkansas	100,172	100,249	100,386	100,089
+.Grant County, Arkansas	17,966	18,022	18,149	18,160
+.Greene County, Arkansas	45,740	45,864	46,349	46,448
+.Hempstead County, Arkansas	20,062	19,981	19,679	19,453
+.Hot Spring County, Arkansas	33,046	33,075	33,108	33,203
+.Howard County, Arkansas	12,784	12,755	12,676	12,557
+.Independence County, Arkansas	37,931	37,936	37,742	37,945
+.Izard County, Arkansas	13,574	13,597	13,928	14,048
+.Jackson County, Arkansas	16,760	16,755	16,780	16,624
+.Jefferson County, Arkansas	67,261	66,833	65,649	64,246
+.Johnson County, Arkansas	25,749	25,722	25,977	26,001
+.Lafayette County, Arkansas	6,311	6,299	6,155	6,101
+.Lawrence County, Arkansas	16,216	16,212	16,316	16,205
+.Lee County, Arkansas	8,597	8,528	8,559	8,364
+.Lincoln County, Arkansas	12,936	12,889	13,151	12,916
+.Little River County, Arkansas	12,028	11,975	11,954	11,821
+.Logan County, Arkansas	21,132	21,103	21,207	21,253
+.Lonoke County, Arkansas	74,010	74,046	74,766	75,225
+.Madison County, Arkansas	16,521	16,546	16,936	17,486
+.Marion County, Arkansas	16,832	16,877	16,970	17,254
+.Miller County, Arkansas	42,595	42,579	42,499	42,552
+.Mississippi County, Arkansas	40,692	40,544	39,577	38,896
+.Monroe County, Arkansas	6,799	6,774	6,660	6,564
+.Montgomery County, Arkansas	8,486	8,488	8,638	8,556
+.Nevada County, Arkansas	8,315	8,285	8,195	8,181
+.Newton County, Arkansas	7,225	7,193	7,164	7,078
+.Ouachita County, Arkansas	22,648	22,614	22,344	22,049
+.Perry County, Arkansas	10,021	10,000	9,989	10,063
+.Phillips County, Arkansas	16,576	16,443	15,822	15,304
+.Pike County, Arkansas	10,180	10,172	10,121	10,179
+.Poinsett County, Arkansas	22,965	22,952	22,730	22,495
+.Polk County, Arkansas	19,223	19,187	19,331	19,337
+.Pope County, Arkansas	63,385	63,403	63,756	64,065
+.Prairie County, Arkansas	8,284	8,246	8,094	8,069
+.Pulaski County, Arkansas	399,117	399,246	398,069	399,145
+.Randolph County, Arkansas	18,571	18,590	18,842	18,837
+.St. Francis County, Arkansas	23,089	23,013	22,701	22,451
+.Saline County, Arkansas	123,424	123,815	125,319	127,357
+.Scott County, Arkansas	9,833	9,828	9,795	9,805
+.Searcy County, Arkansas	7,831	7,842	7,880	7,918
+.Sebastian County, Arkansas	127,800	127,800	128,425	129,059
+.Sevier County, Arkansas	15,844	15,779	15,709	15,686
+.Sharp County, Arkansas	17,280	17,319	17,660	17,810
+.Stone County, Arkansas	12,358	12,350	12,432	12,575
+.Union County, Arkansas	39,049	38,926	38,364	37,752
+.Van Buren County, Arkansas	15,797	15,801	15,751	16,102
+.Washington County, Arkansas	245,866	246,756	251,692	256,054
+.White County, Arkansas	76,822	76,851	77,157	77,755
+.Woodruff County, Arkansas	6,276	6,228	6,153	6,049
+.Yell County, Arkansas	20,259	20,214	20,152	20,129
+.Alameda County, California	1,682,331	1,680,380	1,643,837	1,628,997
+.Alpine County, California	1,201	1,204	1,235	1,190
+.Amador County, California	40,474	40,532	41,144	41,412
+.Butte County, California	211,631	210,135	206,190	207,303
+.Calaveras County, California	45,285	45,346	46,219	46,563
+.Colusa County, California	21,837	21,858	21,913	21,914
+.Contra Costa County, California	1,165,927	1,165,986	1,163,298	1,156,966
+.Del Norte County, California	27,745	27,601	27,553	27,082
+.El Dorado County, California	191,184	191,220	193,590	192,646
+.Fresno County, California	1,008,650	1,009,503	1,012,992	1,015,190
+.Glenn County, California	28,915	28,896	28,664	28,339
+.Humboldt County, California	136,465	136,261	134,836	135,010
+.Imperial County, California	179,709	179,595	179,215	178,713
+.Inyo County, California	19,025	19,001	18,927	18,718
+.Kern County, California	909,244	905,828	912,351	916,108
+.Kings County, California	152,488	152,790	152,679	152,981
+.Lake County, California	68,158	68,195	68,584	68,191
+.Lassen County, California	32,730	32,317	31,813	29,904
+.Los Angeles County, California	10,014,042	9,992,236	9,811,842	9,721,138
+.Madera County, California	156,259	156,343	158,910	160,256
+.Marin County, California	262,318	261,282	259,162	256,018
+.Mariposa County, California	17,128	17,118	17,107	17,020
+.Mendocino County, California	91,595	91,361	91,003	89,783
+.Merced County, California	281,202	281,814	284,458	290,014
+.Modoc County, California	8,700	8,663	8,571	8,511
+.Mono County, California	13,198	13,226	13,261	12,978
+.Monterey County, California	439,036	438,390	437,249	432,858
+.Napa County, California	138,024	137,485	136,206	134,300
+.Nevada County, California	102,235	102,249	103,457	102,293
+.Orange County, California	3,186,979	3,185,516	3,161,005	3,151,184
+.Placer County, California	404,740	405,889	412,789	417,772
+.Plumas County, California	19,796	19,749	19,940	19,351
+.Riverside County, California	2,418,177	2,422,847	2,453,178	2,473,902
+.Sacramento County, California	1,585,046	1,586,465	1,588,106	1,584,169
+.San Benito County, California	64,207	64,521	66,675	67,579
+.San Bernardino County, California	2,181,662	2,183,239	2,192,882	2,193,656
+.San Diego County, California	3,298,635	3,296,045	3,274,954	3,276,208
+.San Francisco County, California	873,959	870,393	811,253	808,437
+.San Joaquin County, California	779,227	780,558	788,140	793,229
+.San Luis Obispo County, California	282,443	281,879	279,298	282,013
+.San Mateo County, California	764,432	762,511	739,060	729,181
+.Santa Barbara County, California	448,217	448,244	437,434	443,837
+.Santa Clara County, California	1,936,274	1,931,026	1,886,595	1,870,945
+.Santa Cruz County, California	270,869	270,462	260,495	264,370
+.Shasta County, California	182,152	181,984	181,981	180,930
+.Sierra County, California	3,234	3,228	3,295	3,217
+.Siskiyou County, California	44,075	43,991	44,026	43,660
+.Solano County, California	453,490	452,698	450,350	448,747
+.Sonoma County, California	488,875	488,281	484,315	482,650
+.Stanislaus County, California	552,880	553,217	552,851	551,275
+.Sutter County, California	99,631	99,464	99,038	98,503
+.Tehama County, California	65,831	65,682	65,380	65,245
+.Trinity County, California	16,112	16,089	16,061	15,781
+.Tulare County, California	473,117	473,891	476,946	477,544
+.Tuolumne County, California	55,623	55,374	55,065	54,531
+.Ventura County, California	843,843	843,310	839,358	832,605
+.Yolo County, California	216,405	216,291	213,039	222,115
+.Yuba County, California	81,578	81,994	83,216	84,310
+.Adams County, Colorado	519,582	520,479	523,592	527,575
+.Alamosa County, Colorado	16,381	16,377	16,563	16,592
+.Arapahoe County, Colorado	655,058	655,207	656,557	655,808
+.Archuleta County, Colorado	13,356	13,425	13,798	14,003
+.Baca County, Colorado	3,510	3,482	3,487	3,432
+.Bent County, Colorado	5,651	5,478	5,337	5,399
+.Boulder County, Colorado	330,764	330,922	327,075	327,468
+.Broomfield County, Colorado	74,105	74,484	75,375	76,121
+.Chaffee County, Colorado	19,473	19,477	19,711	20,223
+.Cheyenne County, Colorado	1,748	1,744	1,716	1,732
+.Clear Creek County, Colorado	9,394	9,393	9,445	9,355
+.Conejos County, Colorado	7,467	7,458	7,578	7,579
+.Costilla County, Colorado	3,496	3,501	3,595	3,603
+.Crowley County, Colorado	5,919	5,694	5,731	5,614
+.Custer County, Colorado	4,703	4,719	5,064	5,335
+.Delta County, Colorado	31,199	31,051	31,383	31,602
+.Denver County, Colorado	715,538	717,556	711,323	713,252
+.Dolores County, Colorado	2,326	2,332	2,370	2,455
+.Douglas County, Colorado	357,998	360,303	369,825	375,988
+.Eagle County, Colorado	55,730	55,665	55,773	55,285
+.Elbert County, Colorado	26,049	26,207	27,133	27,799
+.El Paso County, Colorado	730,402	732,342	737,228	740,567
+.Fremont County, Colorado	48,938	48,878	49,234	49,621
+.Garfield County, Colorado	61,688	61,792	62,195	62,271
+.Gilpin County, Colorado	5,810	5,824	5,899	5,891
+.Grand County, Colorado	15,717	15,748	15,870	15,769
+.Gunnison County, Colorado	16,917	16,945	17,309	17,267
+.Hinsdale County, Colorado	784	788	773	775
+.Huerfano County, Colorado	6,816	6,827	6,922	7,082
+.Jackson County, Colorado	1,379	1,378	1,357	1,302
+.Jefferson County, Colorado	582,902	583,050	580,926	576,143
+.Kiowa County, Colorado	1,445	1,452	1,446	1,424
+.Kit Carson County, Colorado	7,086	7,066	6,936	6,961
+.Lake County, Colorado	7,428	7,404	7,397	7,327
+.La Plata County, Colorado	55,639	55,675	56,187	56,607
+.Larimer County, Colorado	359,066	359,899	362,713	366,778
+.Las Animas County, Colorado	14,557	14,482	14,318	14,327
+.Lincoln County, Colorado	5,677	5,665	5,477	5,510
+.Logan County, Colorado	21,527	21,204	21,122	20,823
+.Mesa County, Colorado	155,710	156,005	157,434	158,636
+.Mineral County, Colorado	865	871	929	931
+.Moffat County, Colorado	13,291	13,264	13,155	13,177
+.Montezuma County, Colorado	25,846	25,883	26,216	26,468
+.Montrose County, Colorado	42,680	42,817	43,230	43,811
+.Morgan County, Colorado	29,106	29,072	28,995	29,239
+.Otero County, Colorado	18,692	18,667	18,536	18,303
+.Ouray County, Colorado	4,880	4,881	5,059	5,100
+.Park County, Colorado	17,395	17,419	17,758	17,939
+.Phillips County, Colorado	4,537	4,531	4,508	4,449
+.Pitkin County, Colorado	17,358	17,354	17,350	16,876
+.Prowers County, Colorado	11,995	12,010	11,994	11,854
+.Pueblo County, Colorado	168,168	168,325	169,332	169,544
+.Rio Blanco County, Colorado	6,531	6,524	6,453	6,569
+.Rio Grande County, Colorado	11,539	11,538	11,388	11,325
+.Routt County, Colorado	24,824	24,829	25,056	25,007
+.Saguache County, Colorado	6,372	6,393	6,505	6,623
+.San Juan County, Colorado	703	710	740	803
+.San Miguel County, Colorado	8,071	8,054	8,074	8,003
+.Sedgwick County, Colorado	2,402	2,390	2,331	2,295
+.Summit County, Colorado	31,052	30,994	30,971	30,565
+.Teller County, Colorado	24,711	24,747	24,939	24,857
+.Washington County, Colorado	4,814	4,808	4,850	4,812
+.Weld County, Colorado	328,976	331,427	339,811	350,176
+.Yuma County, Colorado	9,990	9,979	9,943	9,899
+.Capitol Planning Region, Connecticut	976,269	973,159	980,757	981,447
+.Greater Bridgeport Planning Region, Connecticut	325,777	324,932	327,229	327,286
+.Lower Connecticut River Valley Planning Region, Connecticut	174,221	173,927	176,095	176,622
+.Naugatuck Valley Planning Region, Connecticut	450,447	449,896	452,894	454,083
+.Northeastern Connecticut Planning Region, Connecticut	95,344	95,274	95,708	96,196
+.Northwest Hills Planning Region, Connecticut	112,456	112,269	112,974	113,234
+.South Central Connecticut Planning Region, Connecticut	570,453	569,237	573,562	573,244
+.Southeastern Connecticut Planning Region, Connecticut	280,444	279,522	280,117	280,403
+.Western Connecticut Planning Region, Connecticut	620,531	619,146	624,019	623,690
+.Kent County, Delaware	181,856	182,362	184,371	186,946
+.New Castle County, Delaware	570,721	570,873	572,714	575,494
+.Sussex County, Delaware	237,380	238,879	247,722	255,956
+.District of Columbia, District of Columbia	689,546	670,868	668,791	671,803
+.Alachua County, Florida	278,475	279,742	281,817	284,030
+.Baker County, Florida	28,263	28,115	28,673	27,803
+.Bay County, Florida	175,204	174,506	179,498	185,134
+.Bradford County, Florida	28,306	28,224	28,050	27,313
+.Brevard County, Florida	606,603	608,713	617,742	630,693
+.Broward County, Florida	1,944,376	1,943,266	1,935,729	1,947,026
+.Calhoun County, Florida	13,644	13,703	13,514	13,464
+.Charlotte County, Florida	186,850	188,013	194,934	202,661
+.Citrus County, Florida	153,855	154,565	158,113	162,529
+.Clay County, Florida	218,250	218,933	222,533	226,589
+.Collier County, Florida	375,760	377,293	387,241	397,994
+.Columbia County, Florida	69,701	69,737	69,902	71,908
+.DeSoto County, Florida	33,975	34,087	34,340	35,312
+.Dixie County, Florida	16,758	16,690	16,905	17,124
+.Duval County, Florida	995,560	997,604	1,002,252	1,016,536
+.Escambia County, Florida	321,897	322,551	323,480	324,878
+.Flagler County, Florida	115,383	116,030	120,904	126,705
+.Franklin County, Florida	12,452	12,463	12,175	12,498
+.Gadsden County, Florida	43,820	43,402	43,554	43,403
+.Gilchrist County, Florida	17,862	17,883	18,306	18,992
+.Glades County, Florida	12,127	12,068	12,268	12,454
+.Gulf County, Florida	14,200	14,264	14,452	15,314
+.Hamilton County, Florida	14,006	13,733	13,082	13,217
+.Hardee County, Florida	25,326	25,331	25,307	25,645
+.Hendry County, Florida	39,626	39,725	40,212	41,339
+.Hernando County, Florida	194,515	195,627	200,649	206,896
+.Highlands County, Florida	101,238	101,345	103,295	105,618
+.Hillsborough County, Florida	1,459,773	1,466,160	1,484,455	1,513,301
+.Holmes County, Florida	19,657	19,569	19,295	19,651
+.Indian River County, Florida	159,789	160,439	163,814	167,352
+.Jackson County, Florida	47,309	47,079	47,154	48,211
+.Jefferson County, Florida	14,507	14,390	14,476	15,042
+.Lafayette County, Florida	8,225	8,214	7,958	7,786
+.Lake County, Florida	383,959	386,194	396,242	410,139
+.Lee County, Florida	760,820	765,504	790,676	822,453
+.Leon County, Florida	292,203	293,948	296,081	297,369
+.Levy County, Florida	42,912	43,059	44,158	45,260
+.Liberty County, Florida	7,976	7,805	7,308	7,603
+.Madison County, Florida	17,970	17,866	18,069	18,198
+.Manatee County, Florida	399,705	401,593	413,474	429,125
+.Marion County, Florida	375,906	377,459	385,084	396,415
+.Martin County, Florida	158,435	158,658	160,249	162,006
+.Miami-Dade County, Florida	2,701,762	2,695,501	2,670,421	2,673,837
+.Monroe County, Florida	82,879	82,852	82,265	81,708
+.Nassau County, Florida	90,355	91,027	94,393	97,899
+.Okaloosa County, Florida	211,664	212,071	213,647	216,482
+.Okeechobee County, Florida	39,636	39,642	40,044	40,412
+.Orange County, Florida	1,429,901	1,431,573	1,427,928	1,452,726
+.Osceola County, Florida	388,664	391,118	404,020	422,545
+.Palm Beach County, Florida	1,492,198	1,494,173	1,503,223	1,518,477
+.Pasco County, Florida	561,897	566,126	584,927	608,794
+.Pinellas County, Florida	959,103	959,465	959,046	961,739
+.Polk County, Florida	725,041	730,111	755,179	787,404
+.Putnam County, Florida	73,327	73,376	74,059	74,731
+.St. Johns County, Florida	273,427	277,085	293,175	306,841
+.St. Lucie County, Florida	329,227	331,428	344,283	358,704
+.Santa Rosa County, Florida	187,991	188,989	193,783	198,268
+.Sarasota County, Florida	434,005	436,207	448,550	462,286
+.Seminole County, Florida	470,855	471,428	471,009	478,772
+.Sumter County, Florida	129,751	130,298	134,867	144,970
+.Suwannee County, Florida	43,472	43,517	44,092	45,411
+.Taylor County, Florida	21,800	21,739	20,786	21,283
+.Union County, Florida	16,138	15,417	15,825	15,460
+.Volusia County, Florida	553,561	555,764	565,988	579,192
+.Wakulla County, Florida	33,766	33,895	34,274	35,178
+.Walton County, Florida	75,306	75,937	79,988	83,304
+.Washington County, Florida	25,322	25,313	24,877	25,414
+.Appling County, Georgia	18,440	18,366	18,411	18,428
+.Atkinson County, Georgia	8,289	8,311	8,358	8,183
+.Bacon County, Georgia	11,140	11,108	11,071	11,191
+.Baker County, Georgia	2,875	2,851	2,827	2,788
+.Baldwin County, Georgia	43,795	43,794	43,671	43,635
+.Banks County, Georgia	18,037	18,082	18,538	19,328
+.Barrow County, Georgia	83,507	83,975	86,672	89,299
+.Bartow County, Georgia	108,888	109,296	110,901	112,816
+.Ben Hill County, Georgia	17,195	17,168	17,152	17,069
+.Berrien County, Georgia	18,166	18,148	18,128	18,214
+.Bibb County, Georgia	157,347	157,025	155,985	156,197
+.Bleckley County, Georgia	12,585	12,524	12,255	12,257
+.Brantley County, Georgia	18,021	18,043	18,121	18,183
+.Brooks County, Georgia	16,299	16,268	16,285	16,253
+.Bryan County, Georgia	44,739	45,035	46,963	48,225
+.Bulloch County, Georgia	79,647	79,918	80,637	83,059
+.Burke County, Georgia	24,594	24,633	24,333	24,388
+.Butts County, Georgia	25,440	25,551	26,114	26,649
+.Calhoun County, Georgia	5,576	5,573	5,534	5,469
+.Camden County, Georgia	54,769	54,925	55,754	57,013
+.Candler County, Georgia	10,990	11,022	11,000	11,000
+.Carroll County, Georgia	119,141	119,484	121,592	124,592
+.Catoosa County, Georgia	67,873	68,006	68,420	68,826
+.Charlton County, Georgia	12,518	12,532	12,813	12,781
+.Chatham County, Georgia	295,280	295,064	295,656	301,107
+.Chattahoochee County, Georgia	9,568	9,481	9,044	8,819
+.Chattooga County, Georgia	24,969	24,922	24,828	24,936
+.Cherokee County, Georgia	266,625	268,175	274,839	281,278
+.Clarke County, Georgia	128,671	128,550	129,185	129,875
+.Clay County, Georgia	2,847	2,830	2,859	2,845
+.Clayton County, Georgia	297,608	297,623	297,318	296,564
+.Clinch County, Georgia	6,746	6,725	6,698	6,662
+.Cobb County, Georgia	766,160	766,374	766,691	771,952
+.Coffee County, Georgia	43,088	43,052	42,997	43,172
+.Colquitt County, Georgia	45,902	45,900	45,757	45,762
+.Columbia County, Georgia	156,010	156,849	159,636	162,419
+.Cook County, Georgia	17,230	17,234	17,266	17,404
+.Coweta County, Georgia	146,154	146,725	149,925	152,882
+.Crawford County, Georgia	12,130	12,103	12,139	12,140
+.Crisp County, Georgia	20,127	20,050	20,024	19,708
+.Dade County, Georgia	16,246	16,235	16,230	16,081
+.Dawson County, Georgia	26,796	27,056	28,475	30,138
+.Decatur County, Georgia	29,369	29,324	29,045	28,982
+.DeKalb County, Georgia	764,386	764,420	759,231	762,820
+.Dodge County, Georgia	19,929	19,874	19,675	19,802
+.Dooly County, Georgia	11,212	11,165	10,881	10,572
+.Dougherty County, Georgia	85,790	85,153	82,267	82,966
+.Douglas County, Georgia	144,227	144,552	145,628	147,316
+.Early County, Georgia	10,855	10,799	10,651	10,574
+.Echols County, Georgia	3,703	3,720	3,708	3,686
+.Effingham County, Georgia	64,768	65,158	66,746	69,041
+.Elbert County, Georgia	19,638	19,667	19,554	19,814
+.Emanuel County, Georgia	22,769	22,887	22,887	22,929
+.Evans County, Georgia	10,772	10,790	10,711	10,695
+.Fannin County, Georgia	25,319	25,434	25,763	25,737
+.Fayette County, Georgia	119,186	119,483	120,681	122,030
+.Floyd County, Georgia	98,586	98,575	98,499	99,443
+.Forsyth County, Georgia	251,283	252,878	260,721	267,237
+.Franklin County, Georgia	23,424	23,468	23,503	24,128
+.Fulton County, Georgia	1,066,702	1,069,370	1,062,531	1,074,634
+.Gilmer County, Georgia	31,354	31,428	32,090	32,407
+.Glascock County, Georgia	2,882	2,894	2,906	2,939
+.Glynn County, Georgia	84,497	84,471	84,705	85,079
+.Gordon County, Georgia	57,543	57,716	58,253	58,954
+.Grady County, Georgia	26,237	26,222	25,879	26,008
+.Greene County, Georgia	18,907	19,021	19,553	20,139
+.Gwinnett County, Georgia	957,027	958,005	965,145	975,353
+.Habersham County, Georgia	46,033	46,138	46,740	47,475
+.Hall County, Georgia	203,166	203,735	207,393	212,692
+.Hancock County, Georgia	8,733	8,708	8,664	8,387
+.Haralson County, Georgia	29,920	30,037	30,579	31,337
+.Harris County, Georgia	34,669	34,896	35,605	36,276
+.Hart County, Georgia	25,824	25,871	26,340	26,909
+.Heard County, Georgia	11,414	11,448	11,529	11,725
+.Henry County, Georgia	240,719	241,848	245,023	248,364
+.Houston County, Georgia	163,641	164,343	167,156	169,631
+.Irwin County, Georgia	9,667	9,650	9,375	9,126
+.Jackson County, Georgia	75,904	76,717	80,317	83,936
+.Jasper County, Georgia	14,595	14,666	15,259	15,951
+.Jeff Davis County, Georgia	14,778	14,799	14,848	14,889
+.Jefferson County, Georgia	15,714	15,678	15,494	15,314
+.Jenkins County, Georgia	8,678	8,666	8,776	8,689
+.Johnson County, Georgia	9,192	9,186	9,034	9,242
+.Jones County, Georgia	28,351	28,397	28,409	28,472
+.Lamar County, Georgia	18,500	18,551	18,684	19,467
+.Lanier County, Georgia	9,880	9,926	10,052	10,171
+.Laurens County, Georgia	49,581	49,544	49,527	49,660
+.Lee County, Georgia	33,162	33,215	33,194	33,642
+.Liberty County, Georgia	65,274	65,317	66,844	68,030
+.Lincoln County, Georgia	7,688	7,701	7,750	7,841
+.Long County, Georgia	16,158	16,269	17,089	18,348
+.Lowndes County, Georgia	118,249	118,415	118,914	119,739
+.Lumpkin County, Georgia	33,487	33,631	32,890	34,796
+.McDuffie County, Georgia	21,625	21,603	21,636	21,713
+.McIntosh County, Georgia	10,975	10,987	11,051	11,180
+.Macon County, Georgia	12,081	12,021	11,832	11,765
+.Madison County, Georgia	30,123	30,269	30,883	31,473
+.Marion County, Georgia	7,506	7,530	7,426	7,449
+.Meriwether County, Georgia	20,610	20,606	20,715	20,845
+.Miller County, Georgia	5,997	5,988	5,886	5,807
+.Mitchell County, Georgia	21,762	21,668	21,266	21,116
+.Monroe County, Georgia	27,955	28,055	28,729	29,427
+.Montgomery County, Georgia	8,610	8,574	8,654	8,655
+.Morgan County, Georgia	20,096	20,198	20,654	21,031
+.Murray County, Georgia	39,982	40,012	40,032	40,472
+.Muscogee County, Georgia	206,922	206,998	205,024	202,616
+.Newton County, Georgia	112,491	112,843	115,318	117,621
+.Oconee County, Georgia	41,799	42,013	43,025	43,588
+.Oglethorpe County, Georgia	14,824	14,867	15,142	15,469
+.Paulding County, Georgia	168,660	169,570	173,921	178,421
+.Peach County, Georgia	27,989	28,040	28,245	28,562
+.Pickens County, Georgia	33,215	33,339	33,990	34,826
+.Pierce County, Georgia	19,716	19,746	19,975	20,168
+.Pike County, Georgia	18,881	18,936	19,534	19,990
+.Polk County, Georgia	42,854	42,923	43,332	43,709
+.Pulaski County, Georgia	9,857	9,873	9,582	9,984
+.Putnam County, Georgia	22,046	22,163	22,643	22,984
+.Quitman County, Georgia	2,238	2,228	2,236	2,249
+.Rabun County, Georgia	16,882	16,914	17,088	17,206
+.Randolph County, Georgia	6,423	6,368	6,253	6,116
+.Richmond County, Georgia	206,607	206,526	205,358	206,640
+.Rockdale County, Georgia	93,554	93,644	93,961	94,984
+.Schley County, Georgia	4,546	4,534	4,476	4,496
+.Screven County, Georgia	14,066	14,078	14,055	13,977
+.Seminole County, Georgia	9,152	9,131	9,142	9,127
+.Spalding County, Georgia	67,301	67,455	67,699	68,919
+.Stephens County, Georgia	26,787	26,820	26,765	26,767
+.Stewart County, Georgia	5,312	5,304	4,914	4,648
+.Sumter County, Georgia	29,612	29,516	28,978	28,877
+.Talbot County, Georgia	5,735	5,726	5,746	5,747
+.Taliaferro County, Georgia	1,562	1,562	1,560	1,600
+.Tattnall County, Georgia	24,287	24,316	24,132	24,064
+.Taylor County, Georgia	7,816	7,819	7,754	7,737
+.Telfair County, Georgia	12,477	12,465	12,330	12,354
+.Terrell County, Georgia	9,184	9,138	8,904	8,754
+.Thomas County, Georgia	45,806	45,785	45,815	45,561
+.Tift County, Georgia	41,347	41,374	41,123	41,412
+.Toombs County, Georgia	27,031	27,081	26,873	26,837
+.Towns County, Georgia	12,487	12,545	12,867	12,972
+.Treutlen County, Georgia	6,401	6,396	6,382	6,365
+.Troup County, Georgia	69,427	69,323	69,479	70,191
+.Turner County, Georgia	9,001	8,983	8,931	8,842
+.Twiggs County, Georgia	8,023	8,011	7,899	7,680
+.Union County, Georgia	24,626	24,798	25,560	26,388
+.Upson County, Georgia	27,699	27,740	27,673	28,086
+.Walker County, Georgia	67,660	67,742	68,405	68,915
+.Walton County, Georgia	96,669	97,153	99,808	103,065
+.Ware County, Georgia	36,247	36,225	35,547	35,614
+.Warren County, Georgia	5,211	5,208	5,214	5,155
+.Washington County, Georgia	19,992	19,948	19,766	19,738
+.Wayne County, Georgia	30,144	30,145	30,246	30,896
+.Webster County, Georgia	2,349	2,352	2,356	2,328
+.Wheeler County, Georgia	7,479	7,447	7,748	7,314
+.White County, Georgia	28,000	28,108	28,393	28,806
+.Whitfield County, Georgia	102,866	102,776	102,688	103,132
+.Wilcox County, Georgia	8,767	8,792	8,746	8,761
+.Wilkes County, Georgia	9,567	9,556	9,516	9,599
+.Wilkinson County, Georgia	8,868	8,824	8,791	8,681
+.Worth County, Georgia	20,783	20,738	20,557	20,424
+.Hawaii County, Hawaii	200,631	200,712	203,792	206,315
+.Honolulu County, Hawaii	1,016,506	1,012,305	1,004,673	995,638
+.Kalawao County, Hawaii	80	80	81	82
+.Kauai County, Hawaii	73,294	73,186	73,791	73,810
+.Maui County, Hawaii	164,762	164,760	164,817	164,351
+.Ada County, Idaho	494,964	498,260	512,914	518,907
+.Adams County, Idaho	4,380	4,425	4,632	4,817
+.Bannock County, Idaho	87,017	87,270	88,349	89,517
+.Bear Lake County, Idaho	6,371	6,367	6,559	6,722
+.Benewah County, Idaho	9,531	9,576	9,941	10,370
+.Bingham County, Idaho	47,995	48,106	48,898	49,923
+.Blaine County, Idaho	24,275	24,342	24,767	24,866
+.Boise County, Idaho	7,613	7,662	8,121	8,333
+.Bonner County, Idaho	47,105	47,402	49,617	51,414
+.Bonneville County, Idaho	123,955	124,716	128,045	129,496
+.Boundary County, Idaho	12,057	12,137	12,635	13,345
+.Butte County, Idaho	2,575	2,583	2,650	2,684
+.Camas County, Idaho	1,073	1,083	1,129	1,153
+.Canyon County, Idaho	231,106	232,998	243,774	251,065
+.Caribou County, Idaho	7,028	7,012	7,110	7,190
+.Cassia County, Idaho	24,693	24,760	25,249	25,655
+.Clark County, Idaho	788	791	793	806
+.Clearwater County, Idaho	8,731	8,752	8,917	9,015
+.Custer County, Idaho	4,274	4,265	4,434	4,506
+.Elmore County, Idaho	28,665	28,669	28,941	29,403
+.Franklin County, Idaho	14,196	14,284	14,676	15,189
+.Fremont County, Idaho	13,383	13,414	13,606	13,978
+.Gem County, Idaho	19,126	19,274	19,832	20,418
+.Gooding County, Idaho	15,599	15,643	15,725	15,715
+.Idaho County, Idaho	16,542	16,588	17,053	17,593
+.Jefferson County, Idaho	30,889	31,077	32,253	33,428
+.Jerome County, Idaho	24,241	24,268	24,745	25,311
+.Kootenai County, Idaho	171,374	172,790	180,146	183,578
+.Latah County, Idaho	39,518	39,629	40,397	40,978
+.Lemhi County, Idaho	7,976	7,958	8,136	8,240
+.Lewis County, Idaho	3,528	3,528	3,709	3,763
+.Lincoln County, Idaho	5,123	5,129	5,260	5,329
+.Madison County, Idaho	52,908	52,929	54,114	54,976
+.Minidoka County, Idaho	21,582	21,666	21,945	22,194
+.Nez Perce County, Idaho	42,089	42,141	42,509	43,004
+.Oneida County, Idaho	4,563	4,562	4,588	4,712
+.Owyhee County, Idaho	11,914	11,994	12,348	12,613
+.Payette County, Idaho	25,385	25,583	26,377	26,956
+.Power County, Idaho	7,874	7,877	7,959	8,068
+.Shoshone County, Idaho	13,164	13,195	13,659	14,012
+.Teton County, Idaho	11,633	11,735	12,294	12,544
+.Twin Falls County, Idaho	90,045	90,361	92,357	93,696
+.Valley County, Idaho	11,744	11,842	12,264	12,464
+.Washington County, Idaho	10,500	10,559	10,887	11,087
+.Adams County, Illinois	65,727	65,612	65,146	64,725
+.Alexander County, Illinois	5,242	5,173	5,032	4,858
+.Bond County, Illinois	16,729	16,688	16,633	16,566
+.Boone County, Illinois	53,446	53,334	53,199	53,154
+.Brown County, Illinois	6,247	6,233	6,443	6,330
+.Bureau County, Illinois	33,229	33,172	32,961	32,828
+.Calhoun County, Illinois	4,435	4,404	4,385	4,360
+.Carroll County, Illinois	15,705	15,667	15,674	15,529
+.Cass County, Illinois	13,044	12,985	12,798	12,657
+.Champaign County, Illinois	205,863	205,629	206,708	206,542
+.Christian County, Illinois	34,031	33,950	33,721	33,436
+.Clark County, Illinois	15,457	15,423	15,354	15,229
+.Clay County, Illinois	13,290	13,271	13,154	13,047
+.Clinton County, Illinois	36,906	36,913	36,886	36,909
+.Coles County, Illinois	46,865	46,761	46,809	46,334
+.Cook County, Illinois	5,275,522	5,261,249	5,177,606	5,109,292
+.Crawford County, Illinois	18,672	18,648	18,691	18,536
+.Cumberland County, Illinois	10,448	10,429	10,343	10,324
+.DeKalb County, Illinois	100,415	100,253	100,472	100,232
+.De Witt County, Illinois	15,510	15,450	15,379	15,310
+.Douglas County, Illinois	19,734	19,758	19,740	19,755
+.DuPage County, Illinois	932,877	931,244	926,448	920,901
+.Edgar County, Illinois	16,868	16,796	16,589	16,433
+.Edwards County, Illinois	6,247	6,208	6,086	6,071
+.Effingham County, Illinois	34,671	34,695	34,531	34,325
+.Fayette County, Illinois	21,492	21,483	21,447	21,305
+.Ford County, Illinois	13,531	13,517	13,491	13,249
+.Franklin County, Illinois	37,798	37,685	37,498	37,242
+.Fulton County, Illinois	33,611	33,488	33,313	33,021
+.Gallatin County, Illinois	4,948	4,938	4,907	4,855
+.Greene County, Illinois	11,988	11,936	11,851	11,651
+.Grundy County, Illinois	52,544	52,517	52,929	53,041
+.Hamilton County, Illinois	7,993	7,997	7,923	7,984
+.Hancock County, Illinois	17,621	17,547	17,388	17,244
+.Hardin County, Illinois	3,647	3,641	3,650	3,597
+.Henderson County, Illinois	6,385	6,334	6,304	6,151
+.Henry County, Illinois	49,290	49,172	48,868	48,419
+.Iroquois County, Illinois	27,079	26,977	26,761	26,473
+.Jackson County, Illinois	52,984	52,906	52,666	52,617
+.Jasper County, Illinois	9,288	9,240	9,204	9,212
+.Jefferson County, Illinois	37,118	36,998	36,882	36,400
+.Jersey County, Illinois	21,520	21,495	21,370	21,246
+.Jo Daviess County, Illinois	22,042	22,057	21,932	21,758
+.Johnson County, Illinois	13,310	13,322	13,471	13,381
+.Kane County, Illinois	516,520	516,141	516,183	514,182
+.Kankakee County, Illinois	107,508	107,250	106,652	106,074
+.Kendall County, Illinois	131,868	132,348	134,948	137,254
+.Knox County, Illinois	49,971	49,799	49,347	48,640
+.Lake County, Illinois	714,351	713,251	712,160	709,150
+.LaSalle County, Illinois	109,663	109,421	109,139	108,078
+.Lawrence County, Illinois	15,283	15,258	15,216	14,914
+.Lee County, Illinois	34,144	34,051	34,166	33,848
+.Livingston County, Illinois	35,816	35,779	35,741	35,521
+.Logan County, Illinois	27,986	27,899	27,970	27,591
+.McDonough County, Illinois	27,237	27,097	26,848	26,861
+.McHenry County, Illinois	310,227	309,886	311,592	311,747
+.McLean County, Illinois	170,975	170,954	171,190	171,141
+.Macon County, Illinois	104,003	103,756	102,649	101,483
+.Macoupin County, Illinois	44,967	44,845	44,545	44,245
+.Madison County, Illinois	265,858	265,610	264,898	263,864
+.Marion County, Illinois	37,727	37,639	37,378	36,914
+.Marshall County, Illinois	11,744	11,706	11,686	11,678
+.Mason County, Illinois	13,091	13,057	12,859	12,748
+.Massac County, Illinois	14,176	14,138	13,966	13,896
+.Menard County, Illinois	12,296	12,271	12,184	12,121
+.Mercer County, Illinois	15,694	15,627	15,568	15,504
+.Monroe County, Illinois	34,953	34,952	34,993	35,033
+.Montgomery County, Illinois	28,287	28,203	28,154	28,020
+.Morgan County, Illinois	32,917	32,838	32,599	32,209
+.Moultrie County, Illinois	14,523	14,476	14,509	14,323
+.Ogle County, Illinois	51,788	51,694	51,474	51,351
+.Peoria County, Illinois	181,833	181,322	179,764	178,383
+.Perry County, Illinois	20,940	20,882	21,033	20,588
+.Piatt County, Illinois	16,672	16,674	16,781	16,723
+.Pike County, Illinois	14,737	14,641	14,609	14,484
+.Pope County, Illinois	3,768	3,758	3,770	3,770
+.Pulaski County, Illinois	5,191	5,160	5,073	4,991
+.Putnam County, Illinois	5,638	5,631	5,596	5,572
+.Randolph County, Illinois	30,165	30,086	30,219	30,068
+.Richland County, Illinois	15,800	15,778	15,685	15,435
+.Rock Island County, Illinois	144,678	144,359	142,992	141,527
+.St. Clair County, Illinois	257,403	256,823	255,022	252,671
+.Saline County, Illinois	23,772	23,688	23,348	23,087
+.Sangamon County, Illinois	196,338	196,122	195,422	194,534
+.Schuyler County, Illinois	6,902	6,871	6,822	6,746
+.Scott County, Illinois	4,947	4,941	4,855	4,790
+.Shelby County, Illinois	20,995	20,924	20,861	20,761
+.Stark County, Illinois	5,405	5,391	5,296	5,345
+.Stephenson County, Illinois	44,623	44,493	44,071	43,627
+.Tazewell County, Illinois	131,334	131,073	130,563	129,911
+.Union County, Illinois	17,243	17,182	16,937	16,767
+.Vermilion County, Illinois	74,199	74,001	73,263	72,337
+.Wabash County, Illinois	11,361	11,315	11,210	11,087
+.Warren County, Illinois	16,840	16,828	16,595	16,354
+.Washington County, Illinois	13,767	13,731	13,651	13,643
+.Wayne County, Illinois	16,173	16,125	15,967	15,872
+.White County, Illinois	13,872	13,807	13,768	13,614
+.Whiteside County, Illinois	55,691	55,553	55,342	54,658
+.Will County, Illinois	696,362	695,844	697,985	696,757
+.Williamson County, Illinois	67,154	67,113	66,943	66,695
+.Winnebago County, Illinois	285,350	284,928	283,559	282,188
+.Woodford County, Illinois	38,450	38,395	38,210	38,128
+.Adams County, Indiana	35,811	35,852	35,939	36,068
+.Allen County, Indiana	385,411	386,082	389,112	391,449
+.Bartholomew County, Indiana	82,218	82,216	82,730	83,540
+.Benton County, Indiana	8,720	8,716	8,714	8,719
+.Blackford County, Indiana	12,115	12,111	12,056	11,919
+.Boone County, Indiana	70,814	71,134	73,006	74,164
+.Brown County, Indiana	15,475	15,482	15,573	15,570
+.Carroll County, Indiana	20,304	20,331	20,502	20,555
+.Cass County, Indiana	37,870	37,791	37,579	37,540
+.Clark County, Indiana	121,091	121,353	122,847	124,237
+.Clay County, Indiana	26,457	26,419	26,370	26,379
+.Clinton County, Indiana	33,188	33,174	33,025	32,843
+.Crawford County, Indiana	10,530	10,525	10,491	10,536
+.Daviess County, Indiana	33,391	33,366	33,381	33,418
+.Dearborn County, Indiana	50,680	50,754	50,946	51,138
+.Decatur County, Indiana	26,471	26,465	26,322	26,416
+.DeKalb County, Indiana	43,273	43,297	43,369	43,731
+.Delaware County, Indiana	111,909	111,763	111,981	112,031
+.Dubois County, Indiana	43,635	43,643	43,625	43,632
+.Elkhart County, Indiana	207,054	206,983	207,066	206,890
+.Fayette County, Indiana	23,404	23,362	23,376	23,349
+.Floyd County, Indiana	80,474	80,509	80,606	80,714
+.Fountain County, Indiana	16,474	16,483	16,466	16,574
+.Franklin County, Indiana	22,796	22,793	22,857	23,028
+.Fulton County, Indiana	20,480	20,469	20,380	20,327
+.Gibson County, Indiana	33,017	33,055	32,954	32,993
+.Grant County, Indiana	66,661	66,475	66,203	66,022
+.Greene County, Indiana	30,805	30,804	30,826	31,006
+.Hamilton County, Indiana	347,465	348,966	357,330	364,921
+.Hancock County, Indiana	79,851	80,187	81,855	83,070
+.Harrison County, Indiana	39,649	39,662	39,817	39,851
+.Hendricks County, Indiana	174,792	175,575	179,555	182,534
+.Henry County, Indiana	48,912	48,903	49,036	48,915
+.Howard County, Indiana	83,659	83,588	83,642	83,574
+.Huntington County, Indiana	36,670	36,646	36,792	36,834
+.Jackson County, Indiana	46,425	46,461	46,285	46,300
+.Jasper County, Indiana	32,912	32,892	33,113	33,281
+.Jay County, Indiana	20,478	20,476	20,309	20,198
+.Jefferson County, Indiana	33,147	33,100	33,119	32,946
+.Jennings County, Indiana	27,614	27,581	27,507	27,536
+.Johnson County, Indiana	161,768	162,224	164,418	165,782
+.Knox County, Indiana	36,286	36,248	35,964	35,789
+.Kosciusko County, Indiana	80,247	80,155	80,323	80,826
+.LaGrange County, Indiana	40,444	40,530	40,538	40,866
+.Lake County, Indiana	498,707	498,932	499,327	499,689
+.LaPorte County, Indiana	112,422	112,276	112,486	111,675
+.Lawrence County, Indiana	45,015	45,012	45,045	45,222
+.Madison County, Indiana	130,141	130,195	130,979	131,744
+.Marion County, Indiana	977,213	976,631	971,647	969,466
+.Marshall County, Indiana	46,096	46,076	46,175	46,332
+.Martin County, Indiana	9,806	9,803	9,799	9,803
+.Miami County, Indiana	35,972	35,913	36,032	35,674
+.Monroe County, Indiana	139,717	139,571	140,135	139,745
+.Montgomery County, Indiana	37,941	37,942	38,061	38,273
+.Morgan County, Indiana	71,785	71,848	72,260	72,236
+.Newton County, Indiana	13,825	13,786	13,793	13,823
+.Noble County, Indiana	47,461	47,453	47,419	47,367
+.Ohio County, Indiana	5,930	5,922	5,992	6,114
+.Orange County, Indiana	19,872	19,848	19,812	19,623
+.Owen County, Indiana	21,326	21,314	21,432	21,482
+.Parke County, Indiana	16,154	16,155	16,486	16,369
+.Perry County, Indiana	19,170	19,151	19,317	19,183
+.Pike County, Indiana	12,252	12,247	12,178	12,168
+.Porter County, Indiana	173,208	173,295	174,517	174,791
+.Posey County, Indiana	25,213	25,173	25,129	25,063
+.Pulaski County, Indiana	12,523	12,523	12,370	12,485
+.Putnam County, Indiana	36,728	36,679	37,016	37,301
+.Randolph County, Indiana	24,502	24,409	24,437	24,437
+.Ripley County, Indiana	28,984	28,968	29,017	29,087
+.Rush County, Indiana	16,755	16,767	16,699	16,673
+.St. Joseph County, Indiana	272,914	272,672	272,341	272,234
+.Scott County, Indiana	24,383	24,371	24,437	24,588
+.Shelby County, Indiana	45,052	45,058	45,025	44,991
+.Spencer County, Indiana	19,814	19,835	19,875	19,967
+.Starke County, Indiana	23,370	23,380	23,378	23,258
+.Steuben County, Indiana	34,448	34,453	34,666	34,725
+.Sullivan County, Indiana	20,820	20,819	20,781	20,670
+.Switzerland County, Indiana	9,753	9,742	9,849	10,006
+.Tippecanoe County, Indiana	186,249	186,369	187,566	188,717
+.Tipton County, Indiana	15,355	15,386	15,393	15,361
+.Union County, Indiana	7,087	7,081	7,014	6,952
+.Vanderburgh County, Indiana	180,136	180,331	180,267	179,744
+.Vermillion County, Indiana	15,447	15,409	15,440	15,451
+.Vigo County, Indiana	106,158	106,119	106,084	106,006
+.Wabash County, Indiana	30,986	30,936	30,897	30,828
+.Warren County, Indiana	8,436	8,424	8,459	8,461
+.Warrick County, Indiana	63,896	63,996	64,623	65,185
+.Washington County, Indiana	28,176	28,242	28,151	28,224
+.Wayne County, Indiana	66,555	66,513	66,490	66,273
+.Wells County, Indiana	28,187	28,167	28,177	28,335
+.White County, Indiana	24,691	24,668	24,662	24,598
+.Whitley County, Indiana	34,190	34,338	34,492	34,627
+.Adair County, Iowa	7,498	7,494	7,538	7,494
+.Adams County, Iowa	3,708	3,710	3,642	3,611
+.Allamakee County, Iowa	14,061	14,068	13,968	13,960
+.Appanoose County, Iowa	12,315	12,285	12,266	12,094
+.Audubon County, Iowa	5,676	5,681	5,665	5,598
+.Benton County, Iowa	25,571	25,534	25,719	25,711
+.Black Hawk County, Iowa	131,147	131,034	130,606	130,274
+.Boone County, Iowa	26,715	26,700	26,776	26,609
+.Bremer County, Iowa	24,988	25,003	25,122	25,259
+.Buchanan County, Iowa	20,565	20,606	20,697	20,714
+.Buena Vista County, Iowa	20,830	20,809	20,767	20,600
+.Butler County, Iowa	14,335	14,332	14,362	14,269
+.Calhoun County, Iowa	9,914	9,882	9,884	9,725
+.Carroll County, Iowa	20,757	20,721	20,752	20,567
+.Cass County, Iowa	13,132	13,118	13,065	13,104
+.Cedar County, Iowa	18,497	18,491	18,444	18,399
+.Cerro Gordo County, Iowa	43,132	43,023	42,761	42,409
+.Cherokee County, Iowa	11,664	11,663	11,532	11,491
+.Chickasaw County, Iowa	12,015	11,990	11,899	11,716
+.Clarke County, Iowa	9,744	9,726	9,756	9,692
+.Clay County, Iowa	16,381	16,335	16,428	16,475
+.Clayton County, Iowa	17,045	17,030	17,047	17,027
+.Clinton County, Iowa	46,470	46,432	46,526	46,344
+.Crawford County, Iowa	16,526	16,490	16,243	16,123
+.Dallas County, Iowa	99,677	100,473	104,069	108,016
+.Davis County, Iowa	9,110	9,112	9,146	9,130
+.Decatur County, Iowa	7,639	7,605	7,660	7,683
+.Delaware County, Iowa	17,484	17,456	17,531	17,568
+.Des Moines County, Iowa	38,907	38,816	38,507	38,293
+.Dickinson County, Iowa	17,704	17,766	17,852	18,028
+.Dubuque County, Iowa	99,264	99,291	98,815	98,677
+.Emmet County, Iowa	9,383	9,335	9,318	9,176
+.Fayette County, Iowa	19,511	19,445	19,309	19,294
+.Floyd County, Iowa	15,627	15,590	15,449	15,337
+.Franklin County, Iowa	10,016	9,997	9,952	9,916
+.Fremont County, Iowa	6,602	6,567	6,575	6,464
+.Greene County, Iowa	8,766	8,752	8,733	8,741
+.Grundy County, Iowa	12,329	12,334	12,371	12,356
+.Guthrie County, Iowa	10,623	10,613	10,586	10,647
+.Hamilton County, Iowa	15,039	15,008	14,883	14,820
+.Hancock County, Iowa	10,794	10,757	10,685	10,685
+.Hardin County, Iowa	16,873	16,820	16,719	16,567
+.Harrison County, Iowa	14,578	14,564	14,683	14,658
+.Henry County, Iowa	20,488	20,451	20,390	20,196
+.Howard County, Iowa	9,468	9,492	9,500	9,533
+.Humboldt County, Iowa	9,598	9,595	9,637	9,572
+.Ida County, Iowa	7,002	7,019	6,974	6,888
+.Iowa County, Iowa	16,663	16,654	16,574	16,475
+.Jackson County, Iowa	19,485	19,452	19,397	19,324
+.Jasper County, Iowa	37,809	37,810	37,874	37,938
+.Jefferson County, Iowa	15,665	15,693	15,762	15,698
+.Johnson County, Iowa	152,861	153,042	155,016	156,420
+.Jones County, Iowa	20,646	20,653	20,839	20,848
+.Keokuk County, Iowa	10,035	10,012	9,924	9,904
+.Kossuth County, Iowa	14,822	14,794	14,524	14,475
+.Lee County, Iowa	33,548	33,520	33,208	32,840
+.Linn County, Iowa	230,303	230,411	229,458	229,033
+.Louisa County, Iowa	10,837	10,821	10,747	10,677
+.Lucas County, Iowa	8,636	8,620	8,696	8,689
+.Lyon County, Iowa	11,934	11,927	12,061	12,179
+.Madison County, Iowa	16,545	16,628	16,789	17,036
+.Mahaska County, Iowa	22,180	22,147	21,944	21,946
+.Marion County, Iowa	33,417	33,408	33,444	33,642
+.Marshall County, Iowa	40,104	40,093	39,899	39,879
+.Mills County, Iowa	14,486	14,399	14,464	14,553
+.Mitchell County, Iowa	10,563	10,588	10,563	10,532
+.Monona County, Iowa	8,757	8,746	8,595	8,486
+.Monroe County, Iowa	7,574	7,597	7,595	7,550
+.Montgomery County, Iowa	10,329	10,330	10,325	10,205
+.Muscatine County, Iowa	43,242	43,141	42,688	42,377
+.O'Brien County, Iowa	14,187	14,154	14,062	14,060
+.Osceola County, Iowa	6,196	6,202	6,163	6,036
+.Page County, Iowa	15,213	15,196	15,215	15,143
+.Palo Alto County, Iowa	8,999	8,989	8,909	8,764
+.Plymouth County, Iowa	25,697	25,689	25,714	25,681
+.Pocahontas County, Iowa	7,077	7,067	7,057	7,053
+.Polk County, Iowa	492,411	492,997	497,675	501,089
+.Pottawattamie County, Iowa	93,670	93,670	93,434	93,173
+.Poweshiek County, Iowa	18,658	18,628	18,603	18,467
+.Ringgold County, Iowa	4,663	4,642	4,626	4,670
+.Sac County, Iowa	9,817	9,794	9,745	9,673
+.Scott County, Iowa	174,669	174,596	174,278	173,924
+.Shelby County, Iowa	11,748	11,723	11,773	11,645
+.Sioux County, Iowa	35,870	35,887	35,991	36,050
+.Story County, Iowa	98,536	98,645	99,666	99,673
+.Tama County, Iowa	17,130	17,077	16,874	16,903
+.Taylor County, Iowa	5,896	5,865	5,873	5,858
+.Union County, Iowa	12,145	12,132	12,036	11,887
+.Van Buren County, Iowa	7,203	7,217	7,261	7,256
+.Wapello County, Iowa	35,445	35,330	35,283	35,043
+.Warren County, Iowa	52,402	52,588	53,487	54,327
+.Washington County, Iowa	22,567	22,540	22,494	22,571
+.Wayne County, Iowa	6,495	6,504	6,511	6,467
+.Webster County, Iowa	36,996	36,985	37,178	36,626
+.Winnebago County, Iowa	10,683	10,662	10,664	10,617
+.Winneshiek County, Iowa	20,061	20,037	19,915	19,974
+.Woodbury County, Iowa	105,944	105,904	105,816	105,671
+.Worth County, Iowa	7,444	7,435	7,380	7,319
+.Wright County, Iowa	12,941	12,915	12,811	12,681
+.Allen County, Kansas	12,522	12,532	12,526	12,579
+.Anderson County, Kansas	7,839	7,843	7,800	7,776
+.Atchison County, Kansas	16,341	16,318	16,257	16,108
+.Barber County, Kansas	4,233	4,203	4,099	4,122
+.Barton County, Kansas	25,495	25,419	25,239	25,080
+.Bourbon County, Kansas	14,361	14,333	14,336	14,493
+.Brown County, Kansas	9,511	9,482	9,453	9,364
+.Butler County, Kansas	67,383	67,390	67,958	68,240
+.Chase County, Kansas	2,576	2,574	2,598	2,548
+.Chautauqua County, Kansas	3,383	3,385	3,391	3,415
+.Cherokee County, Kansas	19,357	19,297	19,208	19,088
+.Cheyenne County, Kansas	2,616	2,615	2,624	2,583
+.Clark County, Kansas	1,988	1,974	1,958	1,933
+.Clay County, Kansas	8,112	8,122	8,091	8,043
+.Cloud County, Kansas	9,034	9,008	8,954	8,946
+.Coffey County, Kansas	8,358	8,356	8,343	8,280
+.Comanche County, Kansas	1,687	1,680	1,660	1,681
+.Cowley County, Kansas	34,547	34,524	34,652	34,453
+.Crawford County, Kansas	38,976	38,951	39,033	39,078
+.Decatur County, Kansas	2,770	2,765	2,764	2,689
+.Dickinson County, Kansas	18,397	18,368	18,483	18,430
+.Doniphan County, Kansas	7,498	7,463	7,442	7,440
+.Douglas County, Kansas	118,784	118,777	119,480	119,964
+.Edwards County, Kansas	2,901	2,883	2,800	2,739
+.Elk County, Kansas	2,479	2,474	2,431	2,441
+.Ellis County, Kansas	28,932	28,943	28,897	28,941
+.Ellsworth County, Kansas	6,383	6,369	6,320	6,355
+.Finney County, Kansas	38,467	38,302	38,066	37,650
+.Ford County, Kansas	34,282	34,208	34,121	33,848
+.Franklin County, Kansas	25,994	26,008	26,021	25,992
+.Geary County, Kansas	36,730	36,751	36,112	35,691
+.Gove County, Kansas	2,717	2,707	2,735	2,717
+.Graham County, Kansas	2,417	2,408	2,408	2,411
+.Grant County, Kansas	7,353	7,326	7,318	7,197
+.Gray County, Kansas	5,654	5,646	5,672	5,729
+.Greeley County, Kansas	1,282	1,274	1,280	1,223
+.Greenwood County, Kansas	6,006	5,965	5,922	5,939
+.Hamilton County, Kansas	2,518	2,489	2,468	2,430
+.Harper County, Kansas	5,484	5,465	5,329	5,323
+.Harvey County, Kansas	34,034	33,998	33,827	33,801
+.Haskell County, Kansas	3,781	3,759	3,646	3,576
+.Hodgeman County, Kansas	1,723	1,739	1,750	1,755
+.Jackson County, Kansas	13,234	13,241	13,270	13,286
+.Jefferson County, Kansas	18,359	18,320	18,419	18,344
+.Jewell County, Kansas	2,938	2,936	2,946	2,898
+.Johnson County, Kansas	609,864	611,101	614,848	619,195
+.Kearny County, Kansas	3,981	3,961	3,892	3,855
+.Kingman County, Kansas	7,461	7,412	7,280	7,193
+.Kiowa County, Kansas	2,458	2,452	2,408	2,404
+.Labette County, Kansas	20,188	20,165	19,929	19,757
+.Lane County, Kansas	1,574	1,569	1,572	1,556
+.Leavenworth County, Kansas	81,897	81,953	82,322	82,892
+.Lincoln County, Kansas	2,940	2,948	2,907	2,899
+.Linn County, Kansas	9,591	9,586	9,730	9,796
+.Logan County, Kansas	2,762	2,743	2,710	2,705
+.Lyon County, Kansas	32,177	32,107	31,987	31,898
+.McPherson County, Kansas	30,220	30,180	30,137	30,012
+.Marion County, Kansas	11,819	11,778	11,756	11,868
+.Marshall County, Kansas	10,038	10,026	10,010	9,982
+.Meade County, Kansas	4,055	4,054	3,989	3,897
+.Miami County, Kansas	34,205	34,232	34,665	34,867
+.Mitchell County, Kansas	5,792	5,772	5,757	5,738
+.Montgomery County, Kansas	31,484	31,393	31,202	30,996
+.Morris County, Kansas	5,389	5,367	5,362	5,349
+.Morton County, Kansas	2,697	2,697	2,669	2,599
+.Nemaha County, Kansas	10,277	10,265	10,216	10,115
+.Neosho County, Kansas	15,902	15,905	15,779	15,606
+.Ness County, Kansas	2,676	2,667	2,651	2,645
+.Norton County, Kansas	5,458	5,453	5,369	5,301
+.Osage County, Kansas	15,770	15,746	15,746	15,654
+.Osborne County, Kansas	3,501	3,497	3,485	3,490
+.Ottawa County, Kansas	5,729	5,728	5,834	5,795
+.Pawnee County, Kansas	6,259	6,261	6,246	6,179
+.Phillips County, Kansas	4,990	4,977	4,845	4,809
+.Pottawatomie County, Kansas	25,344	25,411	25,860	26,273
+.Pratt County, Kansas	9,159	9,148	9,180	9,067
+.Rawlins County, Kansas	2,560	2,565	2,559	2,528
+.Reno County, Kansas	61,898	61,887	61,510	61,516
+.Republic County, Kansas	4,682	4,677	4,682	4,642
+.Rice County, Kansas	9,423	9,385	9,406	9,407
+.Riley County, Kansas	71,963	72,013	71,849	71,108
+.Rooks County, Kansas	4,921	4,895	4,870	4,813
+.Rush County, Kansas	2,951	2,938	2,925	2,927
+.Russell County, Kansas	6,684	6,670	6,677	6,639
+.Saline County, Kansas	54,301	54,253	53,899	53,596
+.Scott County, Kansas	5,151	5,138	5,121	5,014
+.Sedgwick County, Kansas	523,830	524,786	524,481	525,525
+.Seward County, Kansas	21,962	21,854	21,747	21,358
+.Shawnee County, Kansas	178,909	178,698	178,367	177,480
+.Sheridan County, Kansas	2,448	2,451	2,452	2,425
+.Sherman County, Kansas	5,928	5,895	5,911	5,830
+.Smith County, Kansas	3,560	3,552	3,555	3,533
+.Stafford County, Kansas	4,070	4,055	4,008	3,993
+.Stanton County, Kansas	2,085	2,083	2,041	1,963
+.Stevens County, Kansas	5,252	5,246	5,299	5,175
+.Sumner County, Kansas	22,392	22,342	22,386	22,473
+.Thomas County, Kansas	7,933	7,933	7,942	7,893
+.Trego County, Kansas	2,807	2,805	2,792	2,752
+.Wabaunsee County, Kansas	6,872	6,885	6,969	7,019
+.Wallace County, Kansas	1,517	1,517	1,514	1,488
+.Washington County, Kansas	5,532	5,532	5,526	5,501
+.Wichita County, Kansas	2,153	2,149	2,081	2,064
+.Wilson County, Kansas	8,625	8,576	8,537	8,622
+.Woodson County, Kansas	3,115	3,091	3,076	3,109
+.Wyandotte County, Kansas	169,230	168,904	167,290	165,746
+.Adair County, Kentucky	18,903	18,880	18,953	19,067
+.Allen County, Kentucky	20,580	20,573	20,828	21,275
+.Anderson County, Kentucky	23,851	23,870	24,043	24,224
+.Ballard County, Kentucky	7,730	7,712	7,690	7,650
+.Barren County, Kentucky	44,482	44,502	44,599	44,854
+.Bath County, Kentucky	12,747	12,716	12,774	12,829
+.Bell County, Kentucky	24,102	23,984	23,765	23,568
+.Boone County, Kentucky	135,995	136,465	137,760	139,093
+.Bourbon County, Kentucky	20,250	20,290	20,218	20,093
+.Boyd County, Kentucky	48,253	48,197	47,767	48,110
+.Boyle County, Kentucky	30,619	30,753	30,649	30,904
+.Bracken County, Kentucky	8,403	8,402	8,446	8,452
+.Breathitt County, Kentucky	13,717	13,694	13,527	13,351
+.Breckinridge County, Kentucky	20,433	20,443	20,652	20,943
+.Bullitt County, Kentucky	82,226	82,355	83,076	83,836
+.Butler County, Kentucky	12,371	12,318	12,279	12,295
+.Caldwell County, Kentucky	12,648	12,634	12,644	12,570
+.Calloway County, Kentucky	37,098	37,145	37,489	37,685
+.Campbell County, Kentucky	93,075	93,129	92,856	93,300
+.Carlisle County, Kentucky	4,819	4,806	4,760	4,720
+.Carroll County, Kentucky	10,809	10,836	10,884	10,938
+.Carter County, Kentucky	26,626	26,607	26,432	26,395
+.Casey County, Kentucky	15,946	15,924	15,951	15,920
+.Christian County, Kentucky	72,818	72,768	73,221	73,037
+.Clark County, Kentucky	36,993	37,037	36,925	37,061
+.Clay County, Kentucky	20,339	20,310	20,184	19,913
+.Clinton County, Kentucky	9,253	9,232	9,288	9,123
+.Crittenden County, Kentucky	8,988	9,002	8,939	8,981
+.Cumberland County, Kentucky	5,887	5,860	5,892	5,946
+.Daviess County, Kentucky	103,320	103,391	103,140	103,222
+.Edmonson County, Kentucky	12,133	12,153	12,213	12,269
+.Elliott County, Kentucky	7,352	7,333	7,375	7,293
+.Estill County, Kentucky	14,166	14,161	14,090	14,044
+.Fayette County, Kentucky	322,567	322,613	320,473	320,347
+.Fleming County, Kentucky	15,086	15,098	15,268	15,288
+.Floyd County, Kentucky	35,948	35,804	35,300	34,978
+.Franklin County, Kentucky	51,539	51,589	51,683	51,607
+.Fulton County, Kentucky	6,515	6,512	6,513	6,382
+.Gallatin County, Kentucky	8,693	8,672	8,766	8,763
+.Garrard County, Kentucky	16,949	16,965	17,385	17,589
+.Grant County, Kentucky	24,946	25,014	25,302	25,502
+.Graves County, Kentucky	36,657	36,527	36,634	36,412
+.Grayson County, Kentucky	26,418	26,454	26,582	26,631
+.Green County, Kentucky	11,109	11,130	11,308	11,365
+.Greenup County, Kentucky	35,970	35,887	35,682	35,403
+.Hancock County, Kentucky	9,097	9,105	9,083	9,021
+.Hardin County, Kentucky	110,694	110,816	111,766	111,862
+.Harlan County, Kentucky	26,833	26,752	26,177	25,662
+.Harrison County, Kentucky	18,692	18,718	18,964	19,103
+.Hart County, Kentucky	19,281	19,289	19,485	19,600
+.Henderson County, Kentucky	44,791	44,668	44,417	44,046
+.Henry County, Kentucky	15,682	15,697	15,704	15,771
+.Hickman County, Kentucky	4,523	4,530	4,430	4,422
+.Hopkins County, Kentucky	45,422	45,366	45,096	44,812
+.Jackson County, Kentucky	12,958	12,962	12,987	12,973
+.Jefferson County, Kentucky	782,956	782,783	777,378	773,399
+.Jessamine County, Kentucky	52,987	53,016	53,609	54,254
+.Johnson County, Kentucky	22,679	22,644	22,539	22,244
+.Kenton County, Kentucky	169,028	169,246	169,734	170,313
+.Knott County, Kentucky	14,253	14,163	14,033	13,874
+.Knox County, Kentucky	30,196	30,183	30,019	29,791
+.Larue County, Kentucky	14,869	14,877	15,024	15,163
+.Laurel County, Kentucky	62,613	62,728	62,592	62,885
+.Lawrence County, Kentucky	16,293	16,303	16,268	16,109
+.Lee County, Kentucky	7,394	7,372	7,454	7,261
+.Leslie County, Kentucky	10,516	10,471	10,298	10,093
+.Letcher County, Kentucky	21,551	21,465	21,245	20,893
+.Lewis County, Kentucky	13,079	13,082	13,006	12,954
+.Lincoln County, Kentucky	24,276	24,249	24,227	24,360
+.Livingston County, Kentucky	8,892	8,873	8,984	8,963
+.Logan County, Kentucky	27,433	27,515	27,815	27,877
+.Lyon County, Kentucky	8,683	8,678	8,436	9,101
+.McCracken County, Kentucky	67,871	67,911	67,612	67,490
+.McCreary County, Kentucky	16,887	16,857	16,681	16,701
+.McLean County, Kentucky	9,152	9,134	9,127	9,105
+.Madison County, Kentucky	92,707	92,983	93,473	95,187
+.Magoffin County, Kentucky	11,639	11,604	11,476	11,357
+.Marion County, Kentucky	19,577	19,588	19,758	19,775
+.Marshall County, Kentucky	31,661	31,685	31,820	31,777
+.Martin County, Kentucky	11,287	11,249	11,157	11,095
+.Mason County, Kentucky	17,121	17,130	16,965	16,930
+.Meade County, Kentucky	30,011	30,030	30,132	30,001
+.Menifee County, Kentucky	6,114	6,135	6,209	6,250
+.Mercer County, Kentucky	22,643	22,652	22,872	22,902
+.Metcalfe County, Kentucky	10,288	10,286	10,363	10,370
+.Monroe County, Kentucky	11,336	11,316	11,269	11,355
+.Montgomery County, Kentucky	28,104	28,104	28,231	28,367
+.Morgan County, Kentucky	13,724	13,729	13,682	14,120
+.Muhlenberg County, Kentucky	30,930	30,886	30,072	30,455
+.Nelson County, Kentucky	46,737	46,784	47,149	47,392
+.Nicholas County, Kentucky	7,532	7,540	7,750	7,805
+.Ohio County, Kentucky	23,772	23,746	23,730	23,527
+.Oldham County, Kentucky	67,609	67,692	68,232	69,431
+.Owen County, Kentucky	11,271	11,304	11,307	11,290
+.Owsley County, Kentucky	4,052	4,031	3,967	3,929
+.Pendleton County, Kentucky	14,652	14,652	14,611	14,676
+.Perry County, Kentucky	28,465	28,360	27,906	27,361
+.Pike County, Kentucky	58,663	58,443	57,362	56,286
+.Powell County, Kentucky	13,128	13,095	13,110	13,083
+.Pulaski County, Kentucky	65,033	65,104	65,561	65,795
+.Robertson County, Kentucky	2,192	2,181	2,250	2,229
+.Rockcastle County, Kentucky	16,042	16,064	16,151	16,242
+.Rowan County, Kentucky	24,654	24,716	24,586	24,388
+.Russell County, Kentucky	17,990	17,995	18,195	18,178
+.Scott County, Kentucky	57,153	57,520	58,312	59,099
+.Shelby County, Kentucky	48,101	48,243	48,580	48,886
+.Simpson County, Kentucky	19,595	19,626	19,716	19,949
+.Spencer County, Kentucky	19,433	19,510	19,895	20,204
+.Taylor County, Kentucky	26,019	26,000	26,158	26,407
+.Todd County, Kentucky	12,249	12,289	12,321	12,404
+.Trigg County, Kentucky	14,057	14,080	14,202	14,332
+.Trimble County, Kentucky	8,470	8,461	8,553	8,539
+.Union County, Kentucky	13,670	13,665	13,166	12,961
+.Warren County, Kentucky	134,551	135,013	137,148	139,843
+.Washington County, Kentucky	12,028	12,042	12,091	12,061
+.Wayne County, Kentucky	19,559	19,542	19,569	19,681
+.Webster County, Kentucky	13,014	13,017	12,857	12,726
+.Whitley County, Kentucky	36,715	36,695	36,699	36,873
+.Wolfe County, Kentucky	6,561	6,556	6,491	6,400
+.Woodford County, Kentucky	26,874	26,902	27,090	27,062
+.Acadia Parish, Louisiana	57,569	57,472	57,262	56,744
+.Allen Parish, Louisiana	22,751	22,684	22,604	22,320
+.Ascension Parish, Louisiana	126,498	126,966	128,502	130,458
+.Assumption Parish, Louisiana	21,040	20,957	20,726	20,604
+.Avoyelles Parish, Louisiana	39,690	39,638	39,265	38,751
+.Beauregard Parish, Louisiana	36,554	36,600	36,619	36,570
+.Bienville Parish, Louisiana	12,989	12,918	12,800	12,641
+.Bossier Parish, Louisiana	128,736	128,717	129,402	129,276
+.Caddo Parish, Louisiana	237,857	236,928	232,741	229,025
+.Calcasieu Parish, Louisiana	216,779	216,465	205,095	202,418
+.Caldwell Parish, Louisiana	9,642	9,611	9,593	9,554
+.Cameron Parish, Louisiana	5,619	5,623	5,099	4,902
+.Catahoula Parish, Louisiana	8,903	8,841	8,712	8,566
+.Claiborne Parish, Louisiana	14,168	14,103	13,990	13,744
+.Concordia Parish, Louisiana	18,681	18,568	18,373	18,116
+.De Soto Parish, Louisiana	26,809	26,838	26,934	26,853
+.East Baton Rouge Parish, Louisiana	456,781	455,886	453,653	450,544
+.East Carroll Parish, Louisiana	7,460	7,397	7,242	6,990
+.East Feliciana Parish, Louisiana	19,536	19,450	19,319	19,135
+.Evangeline Parish, Louisiana	32,351	32,304	32,190	31,986
+.Franklin Parish, Louisiana	19,774	19,712	19,593	19,308
+.Grant Parish, Louisiana	22,163	22,135	22,212	22,000
+.Iberia Parish, Louisiana	70,293	70,054	69,298	68,327
+.Iberville Parish, Louisiana	30,240	30,058	29,713	29,506
+.Jackson Parish, Louisiana	15,034	14,997	14,922	14,839
+.Jefferson Parish, Louisiana	440,794	439,712	433,929	425,884
+.Jefferson Davis Parish, Louisiana	32,250	32,210	32,413	32,026
+.Lafayette Parish, Louisiana	241,756	242,148	244,922	247,866
+.Lafourche Parish, Louisiana	97,552	97,434	97,537	95,870
+.LaSalle Parish, Louisiana	14,797	14,822	14,793	14,729
+.Lincoln Parish, Louisiana	48,398	48,304	48,153	48,129
+.Livingston Parish, Louisiana	142,284	142,824	146,230	148,425
+.Madison Parish, Louisiana	10,015	9,923	9,804	9,478
+.Morehouse Parish, Louisiana	25,629	25,453	25,000	24,446
+.Natchitoches Parish, Louisiana	37,519	37,388	36,995	36,663
+.Orleans Parish, Louisiana	383,998	383,218	377,063	369,749
+.Ouachita Parish, Louisiana	160,364	160,096	158,919	157,702
+.Plaquemines Parish, Louisiana	23,515	23,458	23,284	22,516
+.Pointe Coupee Parish, Louisiana	20,757	20,670	20,323	20,151
+.Rapides Parish, Louisiana	130,030	129,657	128,748	127,189
+.Red River Parish, Louisiana	7,624	7,587	7,490	7,420
+.Richland Parish, Louisiana	20,049	20,032	19,890	19,826
+.Sabine Parish, Louisiana	22,144	22,093	22,098	21,985
+.St. Bernard Parish, Louisiana	43,766	43,853	44,330	44,479
+.St. Charles Parish, Louisiana	52,548	52,507	52,405	50,998
+.St. Helena Parish, Louisiana	10,925	10,901	10,921	10,822
+.St. James Parish, Louisiana	20,194	20,117	19,790	19,423
+.St. John the Baptist Parish, Louisiana	42,477	42,355	42,021	39,864
+.St. Landry Parish, Louisiana	82,552	82,302	82,283	81,773
+.St. Martin Parish, Louisiana	51,766	51,628	51,573	51,236
+.St. Mary Parish, Louisiana	49,405	49,143	48,188	47,789
+.St. Tammany Parish, Louisiana	264,575	264,986	270,087	273,263
+.Tangipahoa Parish, Louisiana	133,149	133,635	135,508	137,048
+.Tensas Parish, Louisiana	4,147	4,107	4,034	3,846
+.Terrebonne Parish, Louisiana	109,583	109,405	109,013	104,786
+.Union Parish, Louisiana	21,106	21,090	20,996	20,721
+.Vermilion Parish, Louisiana	56,973	56,918	56,854	56,952
+.Vernon Parish, Louisiana	48,754	48,625	48,056	47,247
+.Washington Parish, Louisiana	45,456	45,344	45,176	45,025
+.Webster Parish, Louisiana	36,963	36,875	36,024	35,643
+.West Baton Rouge Parish, Louisiana	27,201	27,258	27,805	28,034
+.West Carroll Parish, Louisiana	9,755	9,693	9,596	9,475
+.West Feliciana Parish, Louisiana	15,307	15,250	15,481	15,381
+.Winn Parish, Louisiana	13,755	13,721	13,507	13,205
+.Androscoggin County, Maine	111,147	111,180	112,648	113,023
+.Aroostook County, Maine	67,107	67,064	67,022	67,255
+.Cumberland County, Maine	303,076	303,570	306,149	307,451
+.Franklin County, Maine	29,447	29,460	30,275	30,474
+.Hancock County, Maine	55,477	55,500	56,403	56,701
+.Kennebec County, Maine	123,636	123,832	124,824	125,540
+.Knox County, Maine	40,608	40,657	41,074	41,164
+.Lincoln County, Maine	35,240	35,249	35,985	36,215
+.Oxford County, Maine	57,766	57,894	58,719	59,495
+.Penobscot County, Maine	152,202	152,165	152,834	153,704
+.Piscataquis County, Maine	16,799	16,805	17,184	17,417
+.Sagadahoc County, Maine	36,699	36,724	37,190	37,393
+.Somerset County, Maine	50,472	50,460	50,715	51,098
+.Waldo County, Maine	39,596	39,654	39,984	40,241
+.Washington County, Maine	31,088	31,087	31,166	31,437
+.York County, Maine	211,981	212,256	215,066	216,732
+.Allegany County, Maryland	68,115	67,955	67,691	67,267
+.Anne Arundel County, Maryland	588,265	589,054	592,052	593,286
+.Baltimore County, Maryland	854,554	853,325	850,634	846,161
+.Calvert County, Maryland	92,785	92,905	94,226	94,573
+.Caroline County, Maryland	33,299	33,273	33,413	33,433
+.Carroll County, Maryland	172,890	172,923	174,208	175,305
+.Cecil County, Maryland	103,726	103,793	104,096	104,942
+.Charles County, Maryland	166,621	166,726	168,870	170,102
+.Dorchester County, Maryland	32,530	32,528	32,625	32,726
+.Frederick County, Maryland	271,709	272,765	280,410	287,079
+.Garrett County, Maryland	28,804	28,792	28,757	28,579
+.Harford County, Maryland	260,924	261,213	263,292	263,867
+.Howard County, Maryland	332,316	332,786	335,287	335,411
+.Kent County, Maryland	19,195	19,114	19,254	19,320
+.Montgomery County, Maryland	1,062,054	1,060,825	1,055,924	1,052,521
+.Prince George's County, Maryland	967,194	965,290	956,254	946,971
+.Queen Anne's County, Maryland	49,871	50,023	50,900	51,711
+.St. Mary's County, Maryland	113,775	113,987	114,664	114,877
+.Somerset County, Maryland	24,618	24,564	24,528	24,546
+.Talbot County, Maryland	37,520	37,481	37,796	37,932
+.Washington County, Maryland	154,709	154,677	155,197	155,590
+.Wicomico County, Maryland	103,586	103,556	104,181	104,664
+.Worcester County, Maryland	52,460	52,511	53,370	53,866
+.Baltimore city, Maryland	585,693	583,139	576,981	569,931
+.Barnstable County, Massachusetts	229,004	228,856	232,594	232,457
+.Berkshire County, Massachusetts	129,036	128,774	128,621	127,859
+.Bristol County, Massachusetts	579,210	576,737	579,895	580,068
+.Dukes County, Massachusetts	20,595	20,579	21,109	20,868
+.Essex County, Massachusetts	809,818	808,491	807,485	806,765
+.Franklin County, Massachusetts	71,035	70,930	70,943	70,894
+.Hampden County, Massachusetts	465,834	464,407	462,849	461,041
+.Hampshire County, Massachusetts	162,305	146,592	163,088	162,588
+.Middlesex County, Massachusetts	1,632,002	1,628,671	1,617,099	1,617,105
+.Nantucket County, Massachusetts	14,251	14,237	14,499	14,421
+.Norfolk County, Massachusetts	725,999	724,322	724,692	725,531
+.Plymouth County, Massachusetts	530,820	530,154	532,919	533,069
+.Suffolk County, Massachusetts	797,941	793,271	771,765	766,381
+.Worcester County, Massachusetts	862,099	859,708	862,132	862,927
+.Alcona County, Michigan	10,167	10,189	10,300	10,417
+.Alger County, Michigan	8,837	8,842	8,789	8,807
+.Allegan County, Michigan	120,499	120,647	121,010	121,210
+.Alpena County, Michigan	28,909	28,880	28,916	28,847
+.Antrim County, Michigan	23,428	23,459	23,884	24,249
+.Arenac County, Michigan	15,007	15,003	15,000	15,089
+.Baraga County, Michigan	8,149	8,140	8,291	8,277
+.Barry County, Michigan	62,428	62,598	63,170	63,554
+.Bay County, Michigan	103,856	103,733	103,251	102,821
+.Benzie County, Michigan	17,973	17,997	18,236	18,297
+.Berrien County, Michigan	154,320	154,183	153,377	152,900
+.Branch County, Michigan	44,860	44,868	45,202	44,531
+.Calhoun County, Michigan	134,293	134,184	133,878	133,289
+.Cass County, Michigan	51,591	51,550	51,501	51,403
+.Charlevoix County, Michigan	26,051	26,034	26,215	26,293
+.Cheboygan County, Michigan	25,586	25,584	25,735	25,940
+.Chippewa County, Michigan	36,784	36,781	35,867	36,293
+.Clare County, Michigan	30,857	30,834	31,128	31,352
+.Clinton County, Michigan	79,123	79,157	79,499	79,748
+.Crawford County, Michigan	12,994	12,993	13,292	13,491
+.Delta County, Michigan	36,896	36,860	36,834	36,741
+.Dickinson County, Michigan	25,952	25,898	25,795	25,874
+.Eaton County, Michigan	109,174	109,176	109,030	108,992
+.Emmet County, Michigan	34,105	34,104	34,280	34,163
+.Genesee County, Michigan	406,217	405,757	404,662	401,983
+.Gladwin County, Michigan	25,386	25,375	25,528	25,728
+.Gogebic County, Michigan	14,377	14,346	14,356	14,319
+.Grand Traverse County, Michigan	95,246	95,411	96,013	96,464
+.Gratiot County, Michigan	41,752	41,667	41,269	41,100
+.Hillsdale County, Michigan	45,759	45,733	45,609	45,762
+.Houghton County, Michigan	37,360	37,238	37,444	37,035
+.Huron County, Michigan	31,408	31,371	31,354	31,248
+.Ingham County, Michigan	284,891	284,640	271,427	284,108
+.Ionia County, Michigan	66,793	66,855	66,797	66,809
+.Iosco County, Michigan	25,230	25,185	25,374	25,521
+.Iron County, Michigan	11,628	11,628	11,576	11,622
+.Isabella County, Michigan	64,396	64,513	64,291	64,447
+.Jackson County, Michigan	160,375	160,225	160,266	160,066
+.Kalamazoo County, Michigan	261,663	261,767	260,688	261,173
+.Kalkaska County, Michigan	17,928	17,916	17,958	18,182
+.Kent County, Michigan	657,984	658,460	659,000	659,083
+.Keweenaw County, Michigan	2,055	2,068	2,118	2,180
+.Lake County, Michigan	12,100	12,094	12,261	12,594
+.Lapeer County, Michigan	88,615	88,572	88,686	88,780
+.Leelanau County, Michigan	22,304	22,312	22,630	22,870
+.Lenawee County, Michigan	99,424	99,320	99,202	98,567
+.Livingston County, Michigan	193,869	193,971	195,277	196,161
+.Luce County, Michigan	5,339	5,336	5,337	5,330
+.Mackinac County, Michigan	10,831	10,816	10,899	10,941
+.Macomb County, Michigan	881,219	880,176	877,385	874,195
+.Manistee County, Michigan	25,029	25,061	25,299	25,287
+.Marquette County, Michigan	66,020	66,012	65,800	66,661
+.Mason County, Michigan	29,063	29,038	29,381	29,409
+.Mecosta County, Michigan	39,713	39,792	40,057	40,720
+.Menominee County, Michigan	23,500	23,450	23,323	23,266
+.Midland County, Michigan	83,498	83,481	83,426	83,674
+.Missaukee County, Michigan	15,048	15,057	15,164	15,213
+.Monroe County, Michigan	154,812	154,893	155,646	155,609
+.Montcalm County, Michigan	66,622	66,648	67,458	67,433
+.Montmorency County, Michigan	9,154	9,164	9,302	9,569
+.Muskegon County, Michigan	175,814	175,848	176,612	176,565
+.Newaygo County, Michigan	49,971	50,095	50,468	50,886
+.Oakland County, Michigan	1,274,395	1,272,413	1,271,891	1,269,431
+.Oceana County, Michigan	26,658	26,713	26,884	26,973
+.Ogemaw County, Michigan	20,769	20,779	20,783	20,970
+.Ontonagon County, Michigan	5,814	5,805	5,855	5,863
+.Osceola County, Michigan	22,890	22,906	23,176	23,274
+.Oscoda County, Michigan	8,225	8,239	8,328	8,404
+.Otsego County, Michigan	25,095	25,138	25,351	25,644
+.Ottawa County, Michigan	296,207	296,889	298,317	300,873
+.Presque Isle County, Michigan	12,981	12,997	13,173	13,361
+.Roscommon County, Michigan	23,450	23,466	23,677	23,708
+.Saginaw County, Michigan	190,128	189,860	189,590	188,330
+.St. Clair County, Michigan	160,382	160,375	160,384	160,151
+.St. Joseph County, Michigan	60,939	60,931	60,850	60,874
+.Sanilac County, Michigan	40,619	40,502	40,604	40,657
+.Schoolcraft County, Michigan	8,049	8,056	8,060	8,188
+.Shiawassee County, Michigan	68,095	68,006	67,998	68,022
+.Tuscola County, Michigan	53,322	53,310	53,046	52,945
+.Van Buren County, Michigan	75,593	75,576	75,703	75,692
+.Washtenaw County, Michigan	372,265	371,817	364,998	366,376
+.Wayne County, Michigan	1,793,549	1,789,129	1,773,073	1,757,043
+.Wexford County, Michigan	33,668	33,685	33,940	34,196
+.Aitkin County, Minnesota	15,703	15,718	15,945	16,126
+.Anoka County, Minnesota	363,892	364,458	367,416	368,864
+.Becker County, Minnesota	35,176	35,194	35,326	35,371
+.Beltrami County, Minnesota	46,230	46,243	46,420	46,799
+.Benton County, Minnesota	41,381	41,357	41,496	41,463
+.Big Stone County, Minnesota	5,168	5,158	5,162	5,144
+.Blue Earth County, Minnesota	69,129	69,211	69,361	69,631
+.Brown County, Minnesota	25,914	25,903	25,883	25,723
+.Carlton County, Minnesota	36,201	36,193	36,455	36,708
+.Carver County, Minnesota	106,914	107,284	108,826	110,034
+.Cass County, Minnesota	30,065	30,142	30,638	31,274
+.Chippewa County, Minnesota	12,594	12,596	12,390	12,284
+.Chisago County, Minnesota	56,621	56,713	57,544	57,988
+.Clay County, Minnesota	65,309	65,332	65,665	65,929
+.Clearwater County, Minnesota	8,521	8,571	8,574	8,649
+.Cook County, Minnesota	5,599	5,595	5,623	5,708
+.Cottonwood County, Minnesota	11,506	11,509	11,578	11,356
+.Crow Wing County, Minnesota	66,122	66,277	67,345	67,948
+.Dakota County, Minnesota	439,884	440,393	442,773	443,341
+.Dodge County, Minnesota	20,873	20,895	20,964	20,981
+.Douglas County, Minnesota	39,002	39,089	39,305	39,668
+.Faribault County, Minnesota	13,922	13,901	13,910	13,926
+.Fillmore County, Minnesota	21,229	21,234	21,303	21,414
+.Freeborn County, Minnesota	30,901	30,902	30,808	30,718
+.Goodhue County, Minnesota	47,580	47,575	48,018	48,013
+.Grant County, Minnesota	6,075	6,094	6,161	6,136
+.Hennepin County, Minnesota	1,281,568	1,281,568	1,266,736	1,260,121
+.Houston County, Minnesota	18,849	18,851	18,829	18,800
+.Hubbard County, Minnesota	21,348	21,392	21,745	21,960
+.Isanti County, Minnesota	41,133	41,385	41,951	42,727
+.Itasca County, Minnesota	45,018	45,035	45,058	45,205
+.Jackson County, Minnesota	9,992	9,992	10,015	9,893
+.Kanabec County, Minnesota	16,027	16,049	16,187	16,463
+.Kandiyohi County, Minnesota	43,733	43,726	43,865	43,839
+.Kittson County, Minnesota	4,217	4,198	4,162	4,059
+.Koochiching County, Minnesota	12,059	12,025	11,944	11,844
+.Lac qui Parle County, Minnesota	6,722	6,702	6,715	6,689
+.Lake County, Minnesota	10,910	10,918	11,009	10,939
+.Lake of the Woods County, Minnesota	3,765	3,764	3,821	3,871
+.Le Sueur County, Minnesota	28,672	28,639	28,918	29,153
+.Lincoln County, Minnesota	5,644	5,628	5,563	5,580
+.Lyon County, Minnesota	25,268	25,170	25,267	25,262
+.McLeod County, Minnesota	36,759	36,738	36,807	36,714
+.Mahnomen County, Minnesota	5,400	5,372	5,387	5,328
+.Marshall County, Minnesota	9,032	9,026	8,979	8,861
+.Martin County, Minnesota	20,024	19,982	19,899	19,650
+.Meeker County, Minnesota	23,400	23,431	23,391	23,496
+.Mille Lacs County, Minnesota	26,467	26,462	26,892	27,280
+.Morrison County, Minnesota	34,010	33,995	34,071	34,246
+.Mower County, Minnesota	40,034	40,054	40,214	40,140
+.Murray County, Minnesota	8,175	8,172	8,145	8,060
+.Nicollet County, Minnesota	34,464	34,504	34,373	34,441
+.Nobles County, Minnesota	22,294	22,207	22,047	21,947
+.Norman County, Minnesota	6,442	6,435	6,442	6,377
+.Olmsted County, Minnesota	162,849	163,028	163,620	164,020
+.Otter Tail County, Minnesota	60,074	60,072	60,222	60,519
+.Pennington County, Minnesota	13,999	13,950	13,806	13,845
+.Pine County, Minnesota	28,883	28,889	29,034	29,446
+.Pipestone County, Minnesota	9,416	9,414	9,352	9,355
+.Polk County, Minnesota	31,194	31,083	30,817	30,731
+.Pope County, Minnesota	11,309	11,326	11,418	11,431
+.Ramsey County, Minnesota	552,362	551,699	542,861	536,413
+.Red Lake County, Minnesota	3,936	3,940	3,932	3,874
+.Redwood County, Minnesota	15,419	15,408	15,397	15,361
+.Renville County, Minnesota	14,730	14,697	14,628	14,525
+.Rice County, Minnesota	67,098	67,086	67,375	67,693
+.Rock County, Minnesota	9,701	9,684	9,674	9,537
+.Roseau County, Minnesota	15,323	15,293	15,260	15,292
+.St. Louis County, Minnesota	200,223	200,064	199,332	199,532
+.Scott County, Minnesota	150,930	151,350	153,408	154,520
+.Sherburne County, Minnesota	97,186	97,580	99,248	100,824
+.Sibley County, Minnesota	14,842	14,810	14,927	14,955
+.Stearns County, Minnesota	158,297	158,467	159,144	160,405
+.Steele County, Minnesota	37,400	37,375	37,409	37,398
+.Stevens County, Minnesota	9,673	9,666	9,704	9,637
+.Swift County, Minnesota	9,835	9,804	9,781	9,755
+.Todd County, Minnesota	25,253	25,277	25,307	25,538
+.Traverse County, Minnesota	3,366	3,361	3,287	3,275
+.Wabasha County, Minnesota	21,380	21,400	21,514	21,658
+.Wadena County, Minnesota	14,065	14,119	14,184	14,307
+.Waseca County, Minnesota	18,966	18,964	18,992	18,893
+.Washington County, Minnesota	267,563	268,372	272,610	275,912
+.Watonwan County, Minnesota	11,251	11,231	11,158	11,075
+.Wilkin County, Minnesota	6,513	6,482	6,410	6,350
+.Winona County, Minnesota	49,662	49,640	49,750	49,478
+.Wright County, Minnesota	141,336	141,860	145,143	148,003
+.Yellow Medicine County, Minnesota	9,533	9,504	9,446	9,486
+.Adams County, Mississippi	29,538	29,419	28,804	28,408
+.Alcorn County, Mississippi	34,743	34,727	34,429	34,204
+.Amite County, Mississippi	12,721	12,699	12,644	12,619
+.Attala County, Mississippi	17,885	17,816	17,706	17,509
+.Benton County, Mississippi	7,644	7,661	7,630	7,550
+.Bolivar County, Mississippi	30,973	30,827	30,180	29,370
+.Calhoun County, Mississippi	13,267	13,222	12,936	12,781
+.Carroll County, Mississippi	9,995	9,930	9,817	9,731
+.Chickasaw County, Mississippi	17,103	17,078	16,973	16,812
+.Choctaw County, Mississippi	8,246	8,208	8,113	8,037
+.Claiborne County, Mississippi	9,135	9,099	8,898	8,805
+.Clarke County, Mississippi	15,615	15,546	15,457	15,271
+.Clay County, Mississippi	18,635	18,621	18,500	18,380
+.Coahoma County, Mississippi	21,393	21,230	20,732	20,197
+.Copiah County, Mississippi	28,371	28,268	27,927	27,719
+.Covington County, Mississippi	18,339	18,298	18,250	18,098
+.DeSoto County, Mississippi	185,317	186,107	189,042	191,723
+.Forrest County, Mississippi	78,163	78,185	77,883	78,110
+.Franklin County, Mississippi	7,681	7,665	7,689	7,642
+.George County, Mississippi	24,348	24,364	24,793	25,206
+.Greene County, Mississippi	13,533	13,530	13,643	13,552
+.Grenada County, Mississippi	21,627	21,572	21,312	21,088
+.Hancock County, Mississippi	46,047	46,117	46,046	46,094
+.Harrison County, Mississippi	208,621	208,811	209,642	211,044
+.Hinds County, Mississippi	227,750	226,763	222,508	217,730
+.Holmes County, Mississippi	17,001	16,879	16,476	16,121
+.Humphreys County, Mississippi	7,790	7,735	7,548	7,333
+.Issaquena County, Mississippi	1,335	1,325	1,297	1,273
+.Itawamba County, Mississippi	23,861	23,862	23,866	23,903
+.Jackson County, Mississippi	143,259	143,377	144,438	144,975
+.Jasper County, Mississippi	16,370	16,352	16,265	16,167
+.Jefferson County, Mississippi	7,260	7,249	7,156	7,087
+.Jefferson Davis County, Mississippi	11,323	11,271	11,158	11,088
+.Jones County, Mississippi	67,248	67,163	66,839	66,569
+.Kemper County, Mississippi	8,981	8,956	8,781	8,654
+.Lafayette County, Mississippi	55,812	55,907	56,857	57,615
+.Lamar County, Mississippi	64,223	64,384	65,395	65,783
+.Lauderdale County, Mississippi	72,983	72,672	71,871	70,904
+.Lawrence County, Mississippi	12,015	11,982	11,774	11,713
+.Leake County, Mississippi	21,272	21,245	21,247	21,135
+.Lee County, Mississippi	83,347	83,310	83,043	82,959
+.Leflore County, Mississippi	28,348	28,191	27,398	26,570
+.Lincoln County, Mississippi	34,906	34,822	34,907	34,717
+.Lowndes County, Mississippi	58,882	58,767	58,129	57,603
+.Madison County, Mississippi	109,149	109,251	109,919	111,113
+.Marion County, Mississippi	24,438	24,370	24,271	24,050
+.Marshall County, Mississippi	33,755	33,778	33,820	34,110
+.Monroe County, Mississippi	34,179	34,138	33,913	33,577
+.Montgomery County, Mississippi	9,822	9,796	9,704	9,530
+.Neshoba County, Mississippi	29,094	28,988	28,863	28,673
+.Newton County, Mississippi	21,293	21,255	21,117	21,029
+.Noxubee County, Mississippi	10,279	10,228	10,114	9,990
+.Oktibbeha County, Mississippi	51,780	51,698	51,808	51,427
+.Panola County, Mississippi	33,209	33,171	32,919	32,661
+.Pearl River County, Mississippi	56,144	56,198	56,505	57,261
+.Perry County, Mississippi	11,514	11,458	11,490	11,368
+.Pike County, Mississippi	40,329	40,190	39,957	39,644
+.Pontotoc County, Mississippi	31,192	31,194	31,336	31,389
+.Prentiss County, Mississippi	25,000	24,962	24,921	24,792
+.Quitman County, Mississippi	6,173	6,154	5,911	5,701
+.Rankin County, Mississippi	157,026	157,149	158,183	158,979
+.Scott County, Mississippi	27,987	27,968	27,650	27,707
+.Sharkey County, Mississippi	3,798	3,769	3,648	3,488
+.Simpson County, Mississippi	25,950	25,892	25,686	25,587
+.Smith County, Mississippi	14,209	14,194	14,191	14,092
+.Stone County, Mississippi	18,336	18,332	18,589	18,669
+.Sunflower County, Mississippi	25,973	25,853	25,328	24,811
+.Tallahatchie County, Mississippi	12,715	12,650	12,302	12,035
+.Tate County, Mississippi	28,066	28,117	28,118	28,296
+.Tippah County, Mississippi	21,810	21,732	21,614	21,431
+.Tishomingo County, Mississippi	18,854	18,843	18,732	18,619
+.Tunica County, Mississippi	9,777	9,723	9,652	9,458
+.Union County, Mississippi	27,782	27,810	28,001	28,125
+.Walthall County, Mississippi	13,882	13,868	13,804	13,761
+.Warren County, Mississippi	44,721	44,544	43,450	42,649
+.Washington County, Mississippi	44,918	44,631	43,641	42,514
+.Wayne County, Mississippi	19,774	19,803	19,712	19,681
+.Webster County, Mississippi	9,924	9,901	9,981	9,993
+.Wilkinson County, Mississippi	8,586	8,524	8,288	8,143
+.Winston County, Mississippi	17,709	17,683	17,608	17,543
+.Yalobusha County, Mississippi	12,487	12,443	12,409	12,364
+.Yazoo County, Mississippi	26,748	26,671	26,432	25,948
+.Adair County, Missouri	25,315	25,269	25,179	25,165
+.Andrew County, Missouri	18,128	18,098	18,009	18,003
+.Atchison County, Missouri	5,306	5,308	5,227	5,182
+.Audrain County, Missouri	24,964	24,798	24,824	24,434
+.Barry County, Missouri	34,533	34,541	34,733	34,926
+.Barton County, Missouri	11,625	11,608	11,649	11,694
+.Bates County, Missouri	16,032	16,045	16,084	16,177
+.Benton County, Missouri	19,395	19,424	19,916	20,224
+.Bollinger County, Missouri	10,572	10,559	10,578	10,518
+.Boone County, Missouri	183,607	184,035	186,075	187,690
+.Buchanan County, Missouri	84,798	84,460	83,655	82,911
+.Butler County, Missouri	42,128	42,059	42,150	42,179
+.Caldwell County, Missouri	8,813	8,824	8,896	8,933
+.Callaway County, Missouri	44,290	44,337	44,667	44,762
+.Camden County, Missouri	42,746	42,802	43,527	43,768
+.Cape Girardeau County, Missouri	81,707	81,811	82,147	82,899
+.Carroll County, Missouri	8,497	8,468	8,403	8,423
+.Carter County, Missouri	5,201	5,202	5,339	5,268
+.Cass County, Missouri	107,816	108,145	109,751	110,394
+.Cedar County, Missouri	14,187	14,210	14,518	14,601
+.Chariton County, Missouri	7,409	7,384	7,361	7,386
+.Christian County, Missouri	88,846	89,284	91,541	93,114
+.Clark County, Missouri	6,640	6,661	6,738	6,723
+.Clay County, Missouri	253,322	254,112	255,860	257,033
+.Clinton County, Missouri	21,182	21,210	21,258	21,328
+.Cole County, Missouri	77,284	76,614	76,631	76,969
+.Cooper County, Missouri	17,108	16,648	16,672	16,772
+.Crawford County, Missouri	23,059	23,037	22,818	22,659
+.Dade County, Missouri	7,571	7,587	7,600	7,660
+.Dallas County, Missouri	17,070	17,130	17,371	17,626
+.Daviess County, Missouri	8,426	8,425	8,385	8,435
+.DeKalb County, Missouri	11,039	11,610	11,708	11,336
+.Dent County, Missouri	14,419	14,389	14,428	14,467
+.Douglas County, Missouri	11,575	11,604	11,754	11,975
+.Dunklin County, Missouri	28,286	28,217	27,751	27,406
+.Franklin County, Missouri	104,688	104,853	105,328	105,879
+.Gasconade County, Missouri	14,794	14,760	14,791	14,768
+.Gentry County, Missouri	6,165	6,134	6,169	6,253
+.Greene County, Missouri	298,915	299,312	301,118	303,293
+.Grundy County, Missouri	9,814	9,761	9,761	9,838
+.Harrison County, Missouri	8,158	8,156	8,170	8,199
+.Henry County, Missouri	21,946	21,974	22,221	22,438
+.Hickory County, Missouri	8,277	8,301	8,594	8,630
+.Holt County, Missouri	4,226	4,184	4,241	4,262
+.Howard County, Missouri	10,148	10,151	10,128	10,168
+.Howell County, Missouri	39,748	39,793	39,980	40,631
+.Iron County, Missouri	9,537	9,514	9,421	9,414
+.Jackson County, Missouri	717,206	717,572	717,616	716,531
+.Jasper County, Missouri	122,750	122,878	123,325	124,075
+.Jefferson County, Missouri	226,572	226,927	227,934	229,336
+.Johnson County, Missouri	54,007	54,018	54,170	54,368
+.Knox County, Missouri	3,745	3,739	3,787	3,776
+.Laclede County, Missouri	36,042	36,044	36,135	36,313
+.Lafayette County, Missouri	32,994	33,062	32,832	32,961
+.Lawrence County, Missouri	37,995	37,977	38,268	38,683
+.Lewis County, Missouri	10,036	10,039	9,986	9,891
+.Lincoln County, Missouri	59,577	59,849	61,654	63,155
+.Linn County, Missouri	11,870	11,852	11,843	11,820
+.Livingston County, Missouri	14,546	13,988	14,223	14,402
+.McDonald County, Missouri	23,308	23,286	23,428	23,588
+.Macon County, Missouri	15,212	15,197	15,167	15,049
+.Madison County, Missouri	12,627	12,626	12,671	12,753
+.Maries County, Missouri	8,430	8,452	8,422	8,431
+.Marion County, Missouri	28,527	28,480	28,502	28,438
+.Mercer County, Missouri	3,537	3,513	3,469	3,437
+.Miller County, Missouri	24,726	24,770	24,943	25,403
+.Mississippi County, Missouri	12,575	12,130	12,129	11,688
+.Moniteau County, Missouri	15,477	15,213	15,284	15,220
+.Monroe County, Missouri	8,662	8,686	8,720	8,652
+.Montgomery County, Missouri	11,319	11,287	11,429	11,470
+.Morgan County, Missouri	21,000	20,990	21,417	21,785
+.New Madrid County, Missouri	16,435	16,331	16,024	15,695
+.Newton County, Missouri	58,644	58,684	59,437	60,011
+.Nodaway County, Missouri	21,240	21,000	20,984	20,670
+.Oregon County, Missouri	8,641	8,611	8,639	8,732
+.Osage County, Missouri	13,281	13,265	13,409	13,399
+.Ozark County, Missouri	8,556	8,520	8,774	8,940
+.Pemiscot County, Missouri	15,661	15,585	15,225	14,841
+.Perry County, Missouri	18,954	18,969	18,956	18,858
+.Pettis County, Missouri	42,984	43,001	43,206	43,353
+.Phelps County, Missouri	44,640	44,560	44,949	45,313
+.Pike County, Missouri	17,590	17,408	17,602	17,664
+.Platte County, Missouri	106,718	107,168	108,720	110,534
+.Polk County, Missouri	31,521	31,612	32,089	32,693
+.Pulaski County, Missouri	53,958	54,017	53,850	53,941
+.Putnam County, Missouri	4,680	4,690	4,696	4,666
+.Ralls County, Missouri	10,355	10,357	10,378	10,420
+.Randolph County, Missouri	24,713	24,454	24,569	24,622
+.Ray County, Missouri	23,160	23,129	23,061	23,107
+.Reynolds County, Missouri	6,093	6,077	6,082	6,006
+.Ripley County, Missouri	10,678	10,670	10,619	10,703
+.St. Charles County, Missouri	405,262	406,385	410,511	413,803
+.St. Clair County, Missouri	9,287	9,351	9,404	9,576
+.Ste. Genevieve County, Missouri	18,479	18,474	18,571	18,644
+.St. Francois County, Missouri	66,926	66,437	67,057	66,969
+.St. Louis County, Missouri	1,004,310	1,003,056	998,227	990,414
+.Saline County, Missouri	23,319	23,323	23,241	23,007
+.Schuyler County, Missouri	4,034	4,010	4,021	4,002
+.Scotland County, Missouri	4,709	4,699	4,679	4,643
+.Scott County, Missouri	38,058	38,020	37,856	37,840
+.Shannon County, Missouri	7,027	7,028	7,085	7,193
+.Shelby County, Missouri	6,104	6,088	5,957	5,982
+.Stoddard County, Missouri	28,674	28,644	28,482	28,377
+.Stone County, Missouri	31,077	31,206	31,605	32,136
+.Sullivan County, Missouri	5,999	5,987	5,916	5,840
+.Taney County, Missouri	56,058	56,057	56,334	56,821
+.Texas County, Missouri	24,495	24,326	24,893	25,336
+.Vernon County, Missouri	19,710	19,669	19,605	19,651
+.Warren County, Missouri	35,538	35,740	36,529	37,260
+.Washington County, Missouri	23,514	23,416	23,444	23,441
+.Wayne County, Missouri	10,973	10,933	10,907	10,792
+.Webster County, Missouri	39,085	39,002	39,580	40,335
+.Worth County, Missouri	1,967	1,962	1,969	1,955
+.Wright County, Missouri	18,187	18,211	18,640	19,156
+.St. Louis city, Missouri	301,574	300,483	293,562	286,578
+.Beaverhead County, Montana	9,374	9,381	9,532	9,719
+.Big Horn County, Montana	13,127	13,082	12,932	12,851
+.Blaine County, Montana	7,042	7,005	6,982	6,936
+.Broadwater County, Montana	6,773	6,857	7,323	7,793
+.Carbon County, Montana	10,476	10,510	10,862	11,179
+.Carter County, Montana	1,415	1,408	1,410	1,382
+.Cascade County, Montana	84,413	84,402	84,498	84,864
+.Chouteau County, Montana	5,896	5,895	5,916	5,898
+.Custer County, Montana	11,867	11,863	11,971	12,032
+.Daniels County, Montana	1,657	1,653	1,669	1,628
+.Dawson County, Montana	8,943	8,923	8,866	8,830
+.Deer Lodge County, Montana	9,424	9,420	9,506	9,510
+.Fallon County, Montana	3,049	3,028	2,984	3,011
+.Fergus County, Montana	11,443	11,469	11,609	11,663
+.Flathead County, Montana	104,349	104,862	108,725	111,814
+.Gallatin County, Montana	118,957	119,585	123,051	124,857
+.Garfield County, Montana	1,170	1,170	1,210	1,218
+.Glacier County, Montana	13,771	13,737	13,743	13,681
+.Golden Valley County, Montana	824	821	818	835
+.Granite County, Montana	3,306	3,308	3,355	3,502
+.Hill County, Montana	16,304	16,263	16,175	16,068
+.Jefferson County, Montana	12,081	12,140	12,472	12,826
+.Judith Basin County, Montana	2,021	2,025	2,052	2,105
+.Lake County, Montana	31,132	31,246	32,075	32,853
+.Lewis and Clark County, Montana	70,967	71,168	72,503	73,832
+.Liberty County, Montana	1,959	1,956	1,934	1,972
+.Lincoln County, Montana	19,678	19,739	20,571	21,525
+.McCone County, Montana	1,728	1,730	1,711	1,709
+.Madison County, Montana	8,626	8,660	8,944	9,265
+.Meagher County, Montana	1,926	1,922	1,960	2,013
+.Mineral County, Montana	4,529	4,565	4,868	5,058
+.Missoula County, Montana	117,924	118,337	119,806	121,041
+.Musselshell County, Montana	4,732	4,745	4,912	5,197
+.Park County, Montana	17,193	17,224	17,531	17,790
+.Petroleum County, Montana	496	500	522	524
+.Phillips County, Montana	4,215	4,208	4,216	4,240
+.Pondera County, Montana	5,905	5,879	6,018	6,078
+.Powder River County, Montana	1,694	1,693	1,707	1,725
+.Powell County, Montana	6,944	6,941	7,012	7,051
+.Prairie County, Montana	1,093	1,093	1,101	1,107
+.Ravalli County, Montana	44,172	44,409	46,125	47,298
+.Richland County, Montana	11,493	11,531	11,342	11,237
+.Roosevelt County, Montana	10,792	10,794	10,808	10,572
+.Rosebud County, Montana	8,331	8,305	8,077	8,088
+.Sanders County, Montana	12,403	12,463	12,975	13,442
+.Sheridan County, Montana	3,542	3,536	3,569	3,564
+.Silver Bow County, Montana	35,128	35,201	35,554	36,068
+.Stillwater County, Montana	8,959	8,997	9,026	9,177
+.Sweet Grass County, Montana	3,677	3,670	3,705	3,715
+.Teton County, Montana	6,230	6,256	6,282	6,368
+.Toole County, Montana	4,973	4,970	5,010	5,082
+.Treasure County, Montana	759	758	769	758
+.Valley County, Montana	7,577	7,556	7,556	7,513
+.Wheatland County, Montana	2,077	2,083	2,045	2,032
+.Wibaux County, Montana	939	937	935	919
+.Yellowstone County, Montana	164,722	165,196	167,397	169,852
+.Adams County, Nebraska	31,202	31,177	30,990	30,970
+.Antelope County, Nebraska	6,292	6,278	6,292	6,293
+.Arthur County, Nebraska	433	432	441	433
+.Banner County, Nebraska	674	677	689	660
+.Blaine County, Nebraska	432	431	461	453
+.Boone County, Nebraska	5,377	5,359	5,400	5,385
+.Box Butte County, Nebraska	10,841	10,826	10,647	10,672
+.Boyd County, Nebraska	1,814	1,805	1,786	1,741
+.Brown County, Nebraska	2,902	2,902	2,912	2,872
+.Buffalo County, Nebraska	50,089	50,195	50,310	50,586
+.Burt County, Nebraska	6,727	6,721	6,706	6,755
+.Butler County, Nebraska	8,360	8,345	8,425	8,427
+.Cass County, Nebraska	26,598	26,601	27,071	27,122
+.Cedar County, Nebraska	8,378	8,372	8,325	8,371
+.Chase County, Nebraska	3,894	3,887	3,829	3,772
+.Cherry County, Nebraska	5,455	5,454	5,447	5,464
+.Cheyenne County, Nebraska	9,468	9,486	9,502	9,511
+.Clay County, Nebraska	6,105	6,105	6,047	6,049
+.Colfax County, Nebraska	10,581	10,557	10,474	10,444
+.Cuming County, Nebraska	9,010	9,008	8,972	8,929
+.Custer County, Nebraska	10,543	10,493	10,476	10,476
+.Dakota County, Nebraska	21,587	21,552	21,256	21,042
+.Dawes County, Nebraska	8,195	8,150	8,131	8,241
+.Dawson County, Nebraska	24,111	24,086	23,934	23,884
+.Deuel County, Nebraska	1,837	1,831	1,857	1,902
+.Dixon County, Nebraska	5,598	5,582	5,546	5,464
+.Dodge County, Nebraska	37,171	37,110	37,120	36,997
+.Douglas County, Nebraska	584,522	585,386	585,467	586,327
+.Dundy County, Nebraska	1,657	1,654	1,630	1,590
+.Fillmore County, Nebraska	5,557	5,572	5,555	5,553
+.Franklin County, Nebraska	2,890	2,890	2,891	2,873
+.Frontier County, Nebraska	2,519	2,504	2,555	2,633
+.Furnas County, Nebraska	4,633	4,626	4,611	4,575
+.Gage County, Nebraska	21,706	21,653	21,611	21,583
+.Garden County, Nebraska	1,872	1,886	1,833	1,837
+.Garfield County, Nebraska	1,815	1,807	1,832	1,801
+.Gosper County, Nebraska	1,894	1,895	1,819	1,808
+.Grant County, Nebraska	613	615	577	576
+.Greeley County, Nebraska	2,186	2,175	2,184	2,227
+.Hall County, Nebraska	62,893	62,760	62,092	62,097
+.Hamilton County, Nebraska	9,431	9,404	9,382	9,429
+.Harlan County, Nebraska	3,076	3,057	3,097	3,054
+.Hayes County, Nebraska	856	853	841	849
+.Hitchcock County, Nebraska	2,616	2,622	2,594	2,598
+.Holt County, Nebraska	10,137	10,113	10,081	10,043
+.Hooker County, Nebraska	711	706	731	686
+.Howard County, Nebraska	6,472	6,484	6,519	6,515
+.Jefferson County, Nebraska	7,242	7,259	7,160	7,154
+.Johnson County, Nebraska	5,287	5,292	5,335	5,287
+.Kearney County, Nebraska	6,677	6,681	6,662	6,690
+.Keith County, Nebraska	8,331	8,325	8,298	8,269
+.Keya Paha County, Nebraska	768	759	787	787
+.Kimball County, Nebraska	3,438	3,411	3,405	3,315
+.Knox County, Nebraska	8,405	8,396	8,436	8,336
+.Lancaster County, Nebraska	322,615	323,144	323,420	324,756
+.Lincoln County, Nebraska	34,680	34,534	34,078	33,685
+.Logan County, Nebraska	718	715	684	675
+.Loup County, Nebraska	603	603	598	599
+.McPherson County, Nebraska	400	397	382	372
+.Madison County, Nebraska	35,584	35,521	35,360	35,368
+.Merrick County, Nebraska	7,659	7,655	7,670	7,721
+.Morrill County, Nebraska	4,555	4,553	4,573	4,527
+.Nance County, Nebraska	3,377	3,390	3,380	3,326
+.Nemaha County, Nebraska	7,076	7,085	7,000	7,035
+.Nuckolls County, Nebraska	4,096	4,090	4,063	4,041
+.Otoe County, Nebraska	15,907	15,897	16,008	16,198
+.Pawnee County, Nebraska	2,545	2,536	2,540	2,528
+.Perkins County, Nebraska	2,861	2,863	2,822	2,829
+.Phelps County, Nebraska	8,964	8,972	8,933	8,988
+.Pierce County, Nebraska	7,315	7,340	7,316	7,332
+.Platte County, Nebraska	34,294	34,283	34,282	34,296
+.Polk County, Nebraska	5,209	5,212	5,159	5,166
+.Red Willow County, Nebraska	10,705	10,686	10,639	10,573
+.Richardson County, Nebraska	7,870	7,860	7,783	7,705
+.Rock County, Nebraska	1,264	1,266	1,271	1,245
+.Saline County, Nebraska	14,291	14,242	14,052	14,116
+.Sarpy County, Nebraska	190,597	191,157	193,798	196,553
+.Saunders County, Nebraska	22,280	22,372	22,798	23,118
+.Scotts Bluff County, Nebraska	36,084	36,036	35,828	35,603
+.Seward County, Nebraska	17,608	17,614	17,584	17,692
+.Sheridan County, Nebraska	5,134	5,104	5,086	4,996
+.Sherman County, Nebraska	2,959	2,956	2,953	2,980
+.Sioux County, Nebraska	1,135	1,144	1,151	1,127
+.Stanton County, Nebraska	5,843	5,822	5,797	5,717
+.Thayer County, Nebraska	5,032	5,019	4,906	4,885
+.Thomas County, Nebraska	668	670	676	671
+.Thurston County, Nebraska	6,769	6,752	6,595	6,507
+.Valley County, Nebraska	4,055	4,055	4,074	4,073
+.Washington County, Nebraska	20,865	20,928	20,993	21,167
+.Wayne County, Nebraska	9,698	9,694	9,843	9,871
+.Webster County, Nebraska	3,396	3,390	3,393	3,336
+.Wheeler County, Nebraska	772	775	787	785
+.York County, Nebraska	14,128	14,103	14,248	14,354
+.Churchill County, Nevada	25,516	25,568	25,671	25,843
+.Clark County, Nevada	2,265,469	2,274,734	2,295,194	2,322,985
+.Douglas County, Nevada	49,484	49,522	49,969	49,628
+.Elko County, Nevada	53,703	53,670	53,811	54,046
+.Esmeralda County, Nevada	729	732	733	744
+.Eureka County, Nevada	1,853	1,853	1,909	1,863
+.Humboldt County, Nevada	17,288	17,276	17,591	17,272
+.Lander County, Nevada	5,732	5,726	5,762	5,766
+.Lincoln County, Nevada	4,505	4,448	4,433	4,482
+.Lyon County, Nevada	59,240	59,466	60,927	61,585
+.Mineral County, Nevada	4,555	4,557	4,615	4,525
+.Nye County, Nevada	51,590	51,960	53,277	54,738
+.Pershing County, Nevada	6,651	6,622	6,442	6,462
+.Storey County, Nevada	4,098	4,106	4,145	4,170
+.Washoe County, Nevada	486,489	487,674	494,281	496,745
+.White Pine County, Nevada	9,078	9,051	8,846	8,788
+.Carson City, Nevada	58,644	58,683	58,796	58,130
+.Belknap County, New Hampshire	63,709	63,775	64,612	64,781
+.Carroll County, New Hampshire	50,098	50,235	51,725	52,199
+.Cheshire County, New Hampshire	76,455	76,541	76,821	77,350
+.Coos County, New Hampshire	31,262	31,227	31,411	31,504
+.Grafton County, New Hampshire	91,112	91,177	90,474	91,126
+.Hillsborough County, New Hampshire	422,941	422,883	424,496	426,594
+.Merrimack County, New Hampshire	153,800	154,022	154,591	156,020
+.Rockingham County, New Hampshire	314,182	314,603	318,214	319,424
+.Strafford County, New Hampshire	130,895	131,055	131,534	132,275
+.Sullivan County, New Hampshire	43,064	43,069	43,627	43,958
+.Atlantic County, New Jersey	274,536	274,172	275,130	275,638
+.Bergen County, New Jersey	955,746	953,617	954,879	952,997
+.Burlington County, New Jersey	461,863	461,648	464,411	466,103
+.Camden County, New Jersey	523,486	523,074	524,124	524,907
+.Cape May County, New Jersey	95,266	95,040	95,768	95,634
+.Cumberland County, New Jersey	154,148	153,692	152,089	151,356
+.Essex County, New Jersey	862,782	859,924	854,121	849,477
+.Gloucester County, New Jersey	302,285	302,554	304,620	306,601
+.Hudson County, New Jersey	724,857	721,832	703,447	703,366
+.Hunterdon County, New Jersey	128,962	128,786	129,668	129,777
+.Mercer County, New Jersey	387,340	386,441	382,116	380,688
+.Middlesex County, New Jersey	863,183	861,314	862,328	861,418
+.Monmouth County, New Jersey	643,608	642,771	646,392	644,098
+.Morris County, New Jersey	509,277	508,384	510,444	511,151
+.Ocean County, New Jersey	637,229	638,422	649,741	655,735
+.Passaic County, New Jersey	525,052	523,406	518,345	513,936
+.Salem County, New Jersey	64,834	64,842	65,058	65,117
+.Somerset County, New Jersey	345,356	344,725	346,331	346,875
+.Sussex County, New Jersey	144,231	143,915	145,645	146,084
+.Union County, New Jersey	575,352	573,617	572,810	569,815
+.Warren County, New Jersey	109,638	109,513	110,494	110,926
+.Bernalillo County, New Mexico	676,438	676,803	674,980	672,508
+.Catron County, New Mexico	3,582	3,611	3,726	3,827
+.Chaves County, New Mexico	65,158	65,148	64,644	63,894
+.Cibola County, New Mexico	27,172	27,102	27,238	26,950
+.Colfax County, New Mexico	12,385	12,353	12,356	12,246
+.Curry County, New Mexico	48,429	48,370	47,960	47,532
+.De Baca County, New Mexico	1,697	1,683	1,679	1,693
+.Doña Ana County, New Mexico	219,567	220,047	221,655	223,337
+.Eddy County, New Mexico	62,314	62,329	60,899	60,400
+.Grant County, New Mexico	28,190	28,203	27,892	27,686
+.Guadalupe County, New Mexico	4,451	4,440	4,432	4,310
+.Harding County, New Mexico	655	655	636	628
+.Hidalgo County, New Mexico	4,180	4,166	4,090	4,003
+.Lea County, New Mexico	74,455	74,635	73,103	72,452
+.Lincoln County, New Mexico	20,273	20,313	20,421	20,411
+.Los Alamos County, New Mexico	19,418	19,415	19,340	19,187
+.Luna County, New Mexico	25,422	25,447	25,486	25,749
+.McKinley County, New Mexico	72,898	72,578	71,484	69,830
+.Mora County, New Mexico	4,185	4,192	4,203	4,169
+.Otero County, New Mexico	67,843	67,873	68,538	68,823
+.Quay County, New Mexico	8,744	8,712	8,624	8,546
+.Rio Arriba County, New Mexico	40,359	40,269	40,249	40,048
+.Roosevelt County, New Mexico	19,197	19,157	19,017	18,934
+.Sandoval County, New Mexico	148,829	149,276	151,439	153,501
+.San Juan County, New Mexico	121,663	121,368	120,866	120,418
+.San Miguel County, New Mexico	27,203	27,129	27,167	26,953
+.Santa Fe County, New Mexico	154,823	155,041	155,404	155,664
+.Sierra County, New Mexico	11,574	11,563	11,498	11,436
+.Socorro County, New Mexico	16,602	16,558	16,303	16,115
+.Taos County, New Mexico	34,488	34,459	34,700	34,580
+.Torrance County, New Mexico	15,045	15,054	15,318	15,454
+.Union County, New Mexico	4,083	4,072	4,097	3,980
+.Valencia County, New Mexico	76,205	76,369	77,233	78,080
+.Albany County, New York	314,838	313,987	316,301	315,811
+.Allegany County, New York	46,446	47,320	46,921	46,694
+.Bronx County, New York	1,472,656	1,461,125	1,421,089	1,379,946
+.Broome County, New York	198,675	198,126	198,703	197,117
+.Cattaraugus County, New York	77,041	76,992	76,650	76,439
+.Cayuga County, New York	76,251	76,198	75,791	74,998
+.Chautauqua County, New York	127,675	127,578	126,785	126,027
+.Chemung County, New York	84,152	83,945	82,830	81,426
+.Chenango County, New York	47,216	47,067	46,637	46,458
+.Clinton County, New York	79,839	79,761	79,996	78,753
+.Columbia County, New York	61,567	61,403	62,039	61,286
+.Cortland County, New York	46,814	46,750	46,489	46,126
+.Delaware County, New York	44,302	44,221	44,753	44,740
+.Dutchess County, New York	295,897	295,398	298,039	297,545
+.Erie County, New York	954,244	952,598	954,350	950,312
+.Essex County, New York	37,362	37,326	37,292	36,910
+.Franklin County, New York	47,556	47,565	47,040	46,373
+.Fulton County, New York	53,322	53,132	53,055	52,669
+.Genesee County, New York	58,394	58,313	57,988	57,535
+.Greene County, New York	47,933	47,912	48,493	48,061
+.Hamilton County, New York	5,102	5,073	5,114	5,118
+.Herkimer County, New York	60,143	60,024	60,082	59,822
+.Jefferson County, New York	116,723	116,273	117,680	116,637
+.Kings County, New York	2,736,075	2,719,044	2,637,486	2,590,516
+.Lewis County, New York	26,580	26,551	26,745	26,699
+.Livingston County, New York	61,842	61,728	61,629	61,516
+.Madison County, New York	68,012	67,927	67,397	67,097
+.Monroe County, New York	759,444	757,790	756,547	752,035
+.Montgomery County, New York	49,526	49,485	49,611	49,623
+.Nassau County, New York	1,395,777	1,390,559	1,391,112	1,383,726
+.New York County, New York	1,694,250	1,677,306	1,578,801	1,596,273
+.Niagara County, New York	212,650	212,125	211,891	210,880
+.Oneida County, New York	232,111	231,575	229,942	228,846
+.Onondaga County, New York	476,511	474,316	472,094	468,249
+.Ontario County, New York	112,459	112,327	112,660	112,707
+.Orange County, New York	401,324	401,088	404,997	405,941
+.Orleans County, New York	40,355	40,225	39,711	39,318
+.Oswego County, New York	117,533	117,440	118,124	118,287
+.Otsego County, New York	58,529	58,377	60,758	60,636
+.Putnam County, New York	97,682	97,632	98,176	98,045
+.Queens County, New York	2,405,464	2,388,586	2,328,141	2,278,029
+.Rensselaer County, New York	161,138	160,900	160,740	159,853
+.Richmond County, New York	495,749	494,586	493,484	491,133
+.Rockland County, New York	338,329	337,394	339,256	339,022
+.St. Lawrence County, New York	108,502	108,554	108,410	107,733
+.Saratoga County, New York	235,499	235,794	237,962	238,797
+.Schenectady County, New York	158,058	159,315	160,214	160,093
+.Schoharie County, New York	29,718	29,752	30,152	30,063
+.Schuyler County, New York	17,894	17,863	17,800	17,650
+.Seneca County, New York	33,811	33,747	33,576	32,882
+.Steuben County, New York	93,577	93,314	93,105	92,599
+.Suffolk County, New York	1,525,936	1,521,950	1,533,118	1,525,465
+.Sullivan County, New York	78,617	78,605	79,694	79,658
+.Tioga County, New York	48,461	48,352	48,087	47,772
+.Tompkins County, New York	105,744	99,784	106,044	104,777
+.Ulster County, New York	181,856	181,627	183,704	182,319
+.Warren County, New York	65,737	65,618	65,773	65,599
+.Washington County, New York	61,302	61,202	60,975	60,841
+.Wayne County, New York	91,286	91,193	91,201	91,125
+.Westchester County, New York	1,004,445	1,001,431	999,607	990,427
+.Wyoming County, New York	40,531	40,427	40,017	39,666
+.Yates County, New York	24,768	24,720	24,634	24,451
+.Alamance County, North Carolina	171,429	171,954	173,876	176,353
+.Alexander County, North Carolina	36,440	36,482	36,467	36,512
+.Alleghany County, North Carolina	10,886	10,897	11,066	11,185
+.Anson County, North Carolina	22,052	22,033	22,254	22,202
+.Ashe County, North Carolina	26,581	26,580	26,764	27,110
+.Avery County, North Carolina	17,812	17,848	17,502	17,571
+.Beaufort County, North Carolina	44,658	44,690	44,438	44,272
+.Bertie County, North Carolina	17,934	17,862	17,425	17,240
+.Bladen County, North Carolina	29,617	29,629	29,565	29,446
+.Brunswick County, North Carolina	136,694	138,157	144,814	153,064
+.Buncombe County, North Carolina	269,446	269,694	271,719	273,589
+.Burke County, North Carolina	87,573	87,577	87,634	87,881
+.Cabarrus County, North Carolina	225,807	227,214	231,726	235,797
+.Caldwell County, North Carolina	80,664	80,632	80,561	80,492
+.Camden County, North Carolina	10,357	10,407	10,816	11,088
+.Carteret County, North Carolina	67,686	67,724	68,718	69,380
+.Caswell County, North Carolina	22,738	22,699	22,701	22,614
+.Catawba County, North Carolina	160,609	160,892	161,821	163,462
+.Chatham County, North Carolina	76,270	76,670	78,111	79,864
+.Cherokee County, North Carolina	28,769	28,858	29,195	29,512
+.Chowan County, North Carolina	13,705	13,701	13,791	13,940
+.Clay County, North Carolina	11,085	11,142	11,350	11,614
+.Cleveland County, North Carolina	99,521	99,799	100,318	100,670
+.Columbus County, North Carolina	50,625	50,487	49,953	49,885
+.Craven County, North Carolina	100,718	100,646	100,277	100,874
+.Cumberland County, North Carolina	334,728	334,391	337,249	336,699
+.Currituck County, North Carolina	28,103	28,401	29,714	31,015
+.Dare County, North Carolina	36,910	37,032	37,889	37,956
+.Davidson County, North Carolina	168,933	169,196	170,794	172,586
+.Davie County, North Carolina	42,715	42,895	43,614	44,090
+.Duplin County, North Carolina	48,705	48,657	48,606	48,990
+.Durham County, North Carolina	324,849	325,561	329,699	332,680
+.Edgecombe County, North Carolina	48,897	48,777	48,370	48,301
+.Forsyth County, North Carolina	382,584	383,166	386,172	389,157
+.Franklin County, North Carolina	68,578	69,115	71,798	74,539
+.Gaston County, North Carolina	227,942	228,514	231,337	234,215
+.Gates County, North Carolina	10,475	10,448	10,403	10,383
+.Graham County, North Carolina	8,029	8,035	8,008	7,980
+.Granville County, North Carolina	61,001	61,060	61,408	61,903
+.Greene County, North Carolina	20,449	20,440	20,261	20,211
+.Guilford County, North Carolina	541,309	539,498	542,756	546,101
+.Halifax County, North Carolina	48,622	48,521	48,377	47,848
+.Harnett County, North Carolina	133,554	133,779	135,669	138,832
+.Haywood County, North Carolina	62,097	62,223	62,504	62,609
+.Henderson County, North Carolina	116,279	116,541	116,988	118,106
+.Hertford County, North Carolina	21,552	21,470	21,172	20,875
+.Hoke County, North Carolina	52,081	52,240	53,235	53,787
+.Hyde County, North Carolina	4,587	4,551	4,625	4,576
+.Iredell County, North Carolina	186,699	187,683	192,227	195,897
+.Jackson County, North Carolina	43,107	42,231	42,520	42,955
+.Johnston County, North Carolina	215,991	217,787	227,313	234,778
+.Jones County, North Carolina	9,173	9,147	9,217	9,233
+.Lee County, North Carolina	63,281	63,428	64,097	65,476
+.Lenoir County, North Carolina	55,124	55,050	54,693	54,633
+.Lincoln County, North Carolina	86,816	87,206	89,870	93,095
+.McDowell County, North Carolina	44,577	44,580	44,586	44,753
+.Macon County, North Carolina	37,016	37,092	37,488	38,065
+.Madison County, North Carolina	21,192	21,228	21,645	21,768
+.Martin County, North Carolina	22,035	21,953	21,742	21,508
+.Mecklenburg County, North Carolina	1,115,526	1,116,788	1,125,809	1,145,392
+.Mitchell County, North Carolina	14,906	14,906	14,982	15,094
+.Montgomery County, North Carolina	25,752	25,719	25,853	25,894
+.Moore County, North Carolina	99,725	100,267	102,952	105,531
+.Nash County, North Carolina	94,967	95,148	95,227	95,789
+.New Hanover County, North Carolina	225,705	226,307	229,930	234,921
+.Northampton County, North Carolina	17,474	17,435	17,093	16,779
+.Onslow County, North Carolina	204,585	204,937	204,660	207,298
+.Orange County, North Carolina	148,707	143,583	148,610	150,477
+.Pamlico County, North Carolina	12,274	12,303	12,347	12,381
+.Pasquotank County, North Carolina	40,568	40,577	40,746	40,938
+.Pender County, North Carolina	60,208	60,642	63,072	65,737
+.Perquimans County, North Carolina	13,006	13,016	13,126	13,210
+.Person County, North Carolina	39,093	39,187	39,172	39,386
+.Pitt County, North Carolina	170,241	170,378	172,273	173,542
+.Polk County, North Carolina	19,330	19,383	19,691	19,986
+.Randolph County, North Carolina	144,151	144,418	145,109	146,043
+.Richmond County, North Carolina	42,953	42,916	42,842	42,778
+.Robeson County, North Carolina	116,516	116,305	116,229	116,663
+.Rockingham County, North Carolina	91,100	91,188	91,260	91,957
+.Rowan County, North Carolina	146,878	147,148	148,012	149,645
+.Rutherford County, North Carolina	64,444	64,479	64,618	64,963
+.Sampson County, North Carolina	59,040	59,078	59,080	59,120
+.Scotland County, North Carolina	34,180	34,141	34,175	34,162
+.Stanly County, North Carolina	62,506	62,638	63,108	64,153
+.Stokes County, North Carolina	44,523	44,565	44,641	45,175
+.Surry County, North Carolina	71,367	71,372	71,196	71,403
+.Swain County, North Carolina	14,115	14,099	14,149	13,967
+.Transylvania County, North Carolina	32,986	33,046	33,255	33,355
+.Tyrrell County, North Carolina	3,247	3,239	3,377	3,365
+.Union County, North Carolina	238,233	239,443	244,260	249,070
+.Vance County, North Carolina	42,570	42,535	42,103	42,138
+.Wake County, North Carolina	1,129,393	1,130,685	1,152,357	1,175,021
+.Warren County, North Carolina	18,642	18,598	18,791	18,713
+.Washington County, North Carolina	11,001	10,976	10,909	10,828
+.Watauga County, North Carolina	54,077	54,117	54,962	55,089
+.Wayne County, North Carolina	117,324	117,266	116,866	117,286
+.Wilkes County, North Carolina	65,968	65,904	65,818	65,784
+.Wilson County, North Carolina	78,786	78,807	78,283	78,449
+.Yadkin County, North Carolina	37,211	37,246	37,258	37,463
+.Yancey County, North Carolina	18,470	18,490	18,776	18,811
+.Adams County, North Dakota	2,200	2,187	2,152	2,115
+.Barnes County, North Dakota	10,848	10,847	10,812	10,758
+.Benson County, North Dakota	5,951	5,931	5,778	5,770
+.Billings County, North Dakota	945	933	961	1,018
+.Bottineau County, North Dakota	6,378	6,384	6,437	6,376
+.Bowman County, North Dakota	2,997	2,984	2,902	2,894
+.Burke County, North Dakota	2,211	2,208	2,173	2,155
+.Burleigh County, North Dakota	98,466	98,594	98,967	99,280
+.Cass County, North Dakota	184,528	184,874	189,293	192,734
+.Cavalier County, North Dakota	3,706	3,694	3,664	3,597
+.Dickey County, North Dakota	5,002	4,971	4,905	4,923
+.Divide County, North Dakota	2,202	2,212	2,191	2,187
+.Dunn County, North Dakota	4,096	4,100	4,025	4,015
+.Eddy County, North Dakota	2,338	2,320	2,322	2,314
+.Emmons County, North Dakota	3,306	3,293	3,262	3,250
+.Foster County, North Dakota	3,396	3,388	3,362	3,378
+.Golden Valley County, North Dakota	1,730	1,720	1,757	1,744
+.Grand Forks County, North Dakota	73,169	73,126	72,512	72,413
+.Grant County, North Dakota	2,302	2,289	2,311	2,243
+.Griggs County, North Dakota	2,306	2,297	2,284	2,252
+.Hettinger County, North Dakota	2,483	2,467	2,422	2,406
+.Kidder County, North Dakota	2,395	2,387	2,361	2,393
+.LaMoure County, North Dakota	4,091	4,101	4,095	4,098
+.Logan County, North Dakota	1,880	1,890	1,882	1,855
+.McHenry County, North Dakota	5,332	5,311	5,239	5,189
+.McIntosh County, North Dakota	2,529	2,511	2,506	2,475
+.McKenzie County, North Dakota	14,709	14,776	13,851	13,908
+.McLean County, North Dakota	9,770	9,756	9,794	9,824
+.Mercer County, North Dakota	8,354	8,348	8,330	8,333
+.Morton County, North Dakota	33,287	33,313	33,560	33,710
+.Mountrail County, North Dakota	9,812	9,807	9,593	9,290
+.Nelson County, North Dakota	3,015	2,993	3,044	2,995
+.Oliver County, North Dakota	1,876	1,869	1,873	1,856
+.Pembina County, North Dakota	6,832	6,823	6,775	6,763
+.Pierce County, North Dakota	3,983	3,968	3,943	3,942
+.Ramsey County, North Dakota	11,604	11,573	11,598	11,515
+.Ransom County, North Dakota	5,699	5,690	5,667	5,640
+.Renville County, North Dakota	2,282	2,273	2,262	2,220
+.Richland County, North Dakota	16,528	16,527	16,570	16,580
+.Rolette County, North Dakota	12,192	12,195	12,086	11,933
+.Sargent County, North Dakota	3,860	3,836	3,819	3,795
+.Sheridan County, North Dakota	1,273	1,267	1,270	1,295
+.Sioux County, North Dakota	3,897	3,882	3,759	3,711
+.Slope County, North Dakota	699	695	686	672
+.Stark County, North Dakota	33,647	33,828	33,059	32,803
+.Steele County, North Dakota	1,788	1,787	1,798	1,788
+.Stutsman County, North Dakota	21,607	21,556	21,591	21,487
+.Towner County, North Dakota	2,163	2,147	2,133	2,064
+.Traill County, North Dakota	8,000	7,988	7,990	7,958
+.Walsh County, North Dakota	10,558	10,524	10,479	10,438
+.Ward County, North Dakota	69,933	69,923	69,437	68,870
+.Wells County, North Dakota	3,986	3,971	3,905	3,930
+.Williams County, North Dakota	40,950	41,184	38,487	38,109
+.Adams County, Ohio	27,474	27,440	27,513	27,420
+.Allen County, Ohio	102,204	102,107	101,792	101,115
+.Ashland County, Ohio	52,443	52,468	52,340	52,181
+.Ashtabula County, Ohio	97,596	97,516	97,452	97,014
+.Athens County, Ohio	62,421	62,371	59,086	58,979
+.Auglaize County, Ohio	46,421	46,461	46,240	45,948
+.Belmont County, Ohio	66,495	66,283	65,895	65,509
+.Brown County, Ohio	43,674	43,671	43,690	43,680
+.Butler County, Ohio	390,378	390,872	387,791	388,420
+.Carroll County, Ohio	26,714	26,697	26,671	26,659
+.Champaign County, Ohio	38,707	38,734	38,782	38,709
+.Clark County, Ohio	135,973	135,879	135,747	134,831
+.Clermont County, Ohio	208,592	208,738	209,867	210,805
+.Clinton County, Ohio	42,022	42,023	42,100	41,964
+.Columbiana County, Ohio	101,873	101,634	101,250	100,511
+.Coshocton County, Ohio	36,602	36,578	36,614	36,571
+.Crawford County, Ohio	42,010	42,003	41,797	41,522
+.Cuyahoga County, Ohio	1,264,813	1,262,523	1,247,808	1,236,041
+.Darke County, Ohio	51,883	51,897	51,645	51,529
+.Defiance County, Ohio	38,274	38,254	38,216	38,187
+.Delaware County, Ohio	214,120	215,139	221,186	226,296
+.Erie County, Ohio	75,619	75,475	74,918	74,501
+.Fairfield County, Ohio	158,918	159,443	161,182	162,898
+.Fayette County, Ohio	28,947	28,971	28,929	28,839
+.Franklin County, Ohio	1,323,800	1,324,357	1,317,560	1,321,820
+.Fulton County, Ohio	42,713	42,643	42,473	42,171
+.Gallia County, Ohio	29,227	29,241	29,220	29,068
+.Geauga County, Ohio	95,403	95,347	95,649	95,469
+.Greene County, Ohio	167,971	168,119	167,628	168,456
+.Guernsey County, Ohio	38,434	38,415	38,263	38,098
+.Hamilton County, Ohio	830,625	830,320	827,501	825,037
+.Hancock County, Ohio	74,926	74,930	74,775	74,861
+.Hardin County, Ohio	30,691	30,724	30,446	30,416
+.Harrison County, Ohio	14,482	14,486	14,476	14,378
+.Henry County, Ohio	27,662	27,663	27,555	27,512
+.Highland County, Ohio	43,317	43,359	43,423	43,391
+.Hocking County, Ohio	28,054	28,039	28,126	27,858
+.Holmes County, Ohio	44,217	44,226	44,374	44,390
+.Huron County, Ohio	58,565	58,485	58,431	58,218
+.Jackson County, Ohio	32,654	32,669	32,518	32,586
+.Jefferson County, Ohio	65,247	65,171	65,111	64,330
+.Knox County, Ohio	62,711	62,783	62,547	63,183
+.Lake County, Ohio	232,524	232,508	232,223	231,842
+.Lawrence County, Ohio	58,236	58,136	57,400	56,653
+.Licking County, Ohio	178,509	178,769	179,962	181,359
+.Logan County, Ohio	46,144	46,106	46,129	46,040
+.Lorain County, Ohio	312,974	313,495	314,165	316,268
+.Lucas County, Ohio	431,273	430,834	429,360	426,643
+.Madison County, Ohio	43,847	43,853	44,404	43,540
+.Mahoning County, Ohio	228,621	228,005	226,443	225,636
+.Marion County, Ohio	65,366	65,399	65,311	64,642
+.Medina County, Ohio	182,475	182,636	183,338	183,512
+.Meigs County, Ohio	22,197	22,149	22,085	21,969
+.Mercer County, Ohio	42,528	42,526	42,369	42,348
+.Miami County, Ohio	108,777	108,950	109,386	110,247
+.Monroe County, Ohio	13,383	13,349	13,324	13,234
+.Montgomery County, Ohio	537,316	537,093	536,169	533,892
+.Morgan County, Ohio	13,802	13,756	13,689	13,668
+.Morrow County, Ohio	34,940	34,973	35,197	35,339
+.Muskingum County, Ohio	86,412	86,450	86,574	86,113
+.Noble County, Ohio	14,106	14,086	14,312	14,335
+.Ottawa County, Ohio	40,355	40,287	40,156	39,978
+.Paulding County, Ohio	18,803	18,805	18,886	18,757
+.Perry County, Ohio	35,409	35,448	35,454	35,480
+.Pickaway County, Ohio	58,537	58,646	58,770	60,023
+.Pike County, Ohio	27,089	27,069	27,059	27,005
+.Portage County, Ohio	161,790	161,833	158,978	161,745
+.Preble County, Ohio	40,998	41,001	40,894	40,596
+.Putnam County, Ohio	34,448	34,395	34,353	34,334
+.Richland County, Ohio	124,933	124,962	125,327	125,319
+.Ross County, Ohio	77,095	77,064	76,540	76,606
+.Sandusky County, Ohio	58,900	58,865	58,763	58,667
+.Scioto County, Ohio	74,012	73,844	73,012	72,194
+.Seneca County, Ohio	55,080	55,051	54,954	54,632
+.Shelby County, Ohio	48,222	48,138	48,030	47,671
+.Stark County, Ohio	374,853	374,486	373,659	372,657
+.Summit County, Ohio	540,436	539,792	537,247	535,882
+.Trumbull County, Ohio	202,069	201,672	201,444	200,643
+.Tuscarawas County, Ohio	93,265	93,183	92,608	91,937
+.Union County, Ohio	62,790	63,089	65,110	66,898
+.Van Wert County, Ohio	28,937	28,919	28,776	28,769
+.Vinton County, Ohio	12,804	12,804	12,707	12,565
+.Warren County, Ohio	242,338	243,201	246,822	249,778
+.Washington County, Ohio	59,769	59,644	59,459	58,901
+.Wayne County, Ohio	116,889	116,906	116,129	116,559
+.Williams County, Ohio	37,106	37,077	36,743	36,652
+.Wood County, Ohio	132,251	132,248	130,331	131,592
+.Wyandot County, Ohio	21,894	21,861	21,704	21,567
+.Adair County, Oklahoma	19,494	19,451	19,479	19,576
+.Alfalfa County, Oklahoma	5,700	5,708	5,681	5,637
+.Atoka County, Oklahoma	14,135	14,154	14,252	14,262
+.Beaver County, Oklahoma	5,052	5,029	4,999	5,016
+.Beckham County, Oklahoma	22,411	22,342	22,044	22,009
+.Blaine County, Oklahoma	8,731	8,702	8,523	8,409
+.Bryan County, Oklahoma	46,072	46,327	47,187	48,182
+.Caddo County, Oklahoma	26,934	26,900	26,441	26,198
+.Canadian County, Oklahoma	154,154	155,425	161,981	169,149
+.Carter County, Oklahoma	48,004	48,036	48,324	48,510
+.Cherokee County, Oklahoma	47,073	47,090	47,631	48,098
+.Choctaw County, Oklahoma	14,203	14,201	14,314	14,358
+.Cimarron County, Oklahoma	2,293	2,290	2,255	2,252
+.Cleveland County, Oklahoma	295,514	296,207	298,099	299,587
+.Coal County, Oklahoma	5,270	5,284	5,319	5,313
+.Comanche County, Oklahoma	121,124	121,125	122,438	123,046
+.Cotton County, Oklahoma	5,523	5,535	5,467	5,477
+.Craig County, Oklahoma	14,104	14,136	14,176	14,123
+.Creek County, Oklahoma	71,753	71,837	72,186	72,699
+.Custer County, Oklahoma	28,521	28,444	28,132	27,886
+.Delaware County, Oklahoma	40,393	40,385	40,927	41,413
+.Dewey County, Oklahoma	4,481	4,474	4,415	4,401
+.Ellis County, Oklahoma	3,747	3,739	3,731	3,657
+.Garfield County, Oklahoma	62,844	62,692	61,947	61,920
+.Garvin County, Oklahoma	25,655	25,645	25,738	25,713
+.Grady County, Oklahoma	54,800	54,873	55,608	56,658
+.Grant County, Oklahoma	4,162	4,174	4,153	4,124
+.Greer County, Oklahoma	5,492	5,493	5,483	5,547
+.Harmon County, Oklahoma	2,488	2,473	2,413	2,428
+.Harper County, Oklahoma	3,266	3,248	3,172	3,129
+.Haskell County, Oklahoma	11,562	11,552	11,601	11,641
+.Hughes County, Oklahoma	13,367	13,348	13,394	13,407
+.Jackson County, Oklahoma	24,785	24,736	24,720	24,556
+.Jefferson County, Oklahoma	5,338	5,325	5,396	5,389
+.Johnston County, Oklahoma	10,276	10,241	10,357	10,406
+.Kay County, Oklahoma	43,701	43,609	43,724	43,668
+.Kingfisher County, Oklahoma	15,187	15,174	15,253	15,293
+.Kiowa County, Oklahoma	8,503	8,493	8,358	8,345
+.Latimer County, Oklahoma	9,446	9,481	9,482	9,630
+.Le Flore County, Oklahoma	48,131	48,195	48,601	48,907
+.Lincoln County, Oklahoma	33,460	33,495	33,856	34,188
+.Logan County, Oklahoma	49,552	49,743	50,924	51,933
+.Love County, Oklahoma	10,146	10,159	10,244	10,218
+.McClain County, Oklahoma	41,667	41,911	43,497	45,306
+.McCurtain County, Oklahoma	30,809	30,838	30,884	30,931
+.McIntosh County, Oklahoma	18,944	18,950	19,262	19,451
+.Major County, Oklahoma	7,781	7,746	7,617	7,502
+.Marshall County, Oklahoma	15,303	15,340	15,546	15,882
+.Mayes County, Oklahoma	39,044	39,053	39,246	39,589
+.Murray County, Oklahoma	13,905	13,877	13,712	13,672
+.Muskogee County, Oklahoma	66,344	66,241	66,255	66,354
+.Noble County, Oklahoma	10,925	10,922	10,942	10,896
+.Nowata County, Oklahoma	9,322	9,322	9,387	9,483
+.Okfuskee County, Oklahoma	11,314	11,271	11,196	11,134
+.Oklahoma County, Oklahoma	796,567	798,200	799,622	802,559
+.Okmulgee County, Oklahoma	36,706	36,686	36,827	36,990
+.Osage County, Oklahoma	45,823	45,778	45,868	45,839
+.Ottawa County, Oklahoma	30,291	30,229	30,400	30,338
+.Pawnee County, Oklahoma	15,551	15,552	15,761	15,757
+.Payne County, Oklahoma	81,649	81,645	82,149	82,794
+.Pittsburg County, Oklahoma	43,774	43,784	43,695	43,613
+.Pontotoc County, Oklahoma	38,065	38,087	38,195	38,141
+.Pottawatomie County, Oklahoma	72,449	72,542	73,092	73,533
+.Pushmataha County, Oklahoma	10,816	10,796	10,789	10,769
+.Roger Mills County, Oklahoma	3,439	3,428	3,361	3,320
+.Rogers County, Oklahoma	95,245	95,387	96,796	98,836
+.Seminole County, Oklahoma	23,562	23,515	23,498	23,351
+.Sequoyah County, Oklahoma	39,280	39,246	39,442	39,667
+.Stephens County, Oklahoma	42,844	42,814	43,174	43,710
+.Texas County, Oklahoma	21,386	21,291	20,822	20,495
+.Tillman County, Oklahoma	6,967	6,948	7,039	6,977
+.Tulsa County, Oklahoma	669,272	670,653	673,961	677,358
+.Wagoner County, Oklahoma	80,986	81,379	84,198	86,644
+.Washington County, Oklahoma	52,452	52,604	52,857	53,242
+.Washita County, Oklahoma	10,922	10,903	10,881	10,732
+.Woods County, Oklahoma	8,622	8,598	8,613	8,587
+.Woodward County, Oklahoma	20,473	20,406	20,216	19,990
+.Baker County, Oregon	16,666	16,725	16,873	16,938
+.Benton County, Oregon	95,183	95,208	96,277	97,630
+.Clackamas County, Oregon	421,404	422,444	423,763	423,177
+.Clatsop County, Oregon	41,078	41,160	41,916	41,695
+.Columbia County, Oregon	52,603	52,730	53,229	53,588
+.Coos County, Oregon	64,929	64,971	65,119	64,990
+.Crook County, Oregon	24,735	24,923	25,753	26,375
+.Curry County, Oregon	23,447	23,516	23,720	23,598
+.Deschutes County, Oregon	198,256	199,454	205,358	206,549
+.Douglas County, Oregon	111,202	111,288	112,057	112,297
+.Gilliam County, Oregon	1,997	2,017	2,015	2,018
+.Grant County, Oregon	7,233	7,241	7,288	7,218
+.Harney County, Oregon	7,499	7,502	7,590	7,515
+.Hood River County, Oregon	23,978	23,958	24,094	24,048
+.Jackson County, Oregon	223,262	223,614	224,327	221,644
+.Jefferson County, Oregon	24,507	24,577	25,122	25,330
+.Josephine County, Oregon	88,092	88,235	88,590	87,730
+.Klamath County, Oregon	69,416	69,547	70,255	70,212
+.Lake County, Oregon	8,158	8,167	8,285	8,385
+.Lane County, Oregon	382,975	383,279	384,063	382,353
+.Lincoln County, Oregon	50,400	50,507	51,026	50,813
+.Linn County, Oregon	128,610	128,978	129,948	130,467
+.Malheur County, Oregon	31,575	31,650	31,709	31,879
+.Marion County, Oregon	345,910	346,339	347,775	346,703
+.Morrow County, Oregon	12,187	12,220	12,358	12,300
+.Multnomah County, Oregon	815,429	816,467	805,593	795,083
+.Polk County, Oregon	87,432	87,950	89,384	89,614
+.Sherman County, Oregon	1,867	1,873	1,912	1,955
+.Tillamook County, Oregon	27,393	27,466	27,800	27,574
+.Umatilla County, Oregon	80,068	80,098	80,154	80,215
+.Union County, Oregon	26,197	26,167	26,276	26,177
+.Wallowa County, Oregon	7,387	7,401	7,554	7,659
+.Wasco County, Oregon	26,663	26,631	26,735	26,561
+.Washington County, Oregon	600,383	601,101	602,494	600,176
+.Wheeler County, Oregon	1,449	1,460	1,453	1,445
+.Yamhill County, Oregon	107,721	107,931	108,436	108,226
+.Adams County, Pennsylvania	103,829	103,779	105,632	106,027
+.Allegheny County, Pennsylvania	1,250,585	1,249,524	1,245,445	1,233,253
+.Armstrong County, Pennsylvania	65,553	65,459	65,138	64,747
+.Beaver County, Pennsylvania	168,228	167,860	166,914	165,677
+.Bedford County, Pennsylvania	47,573	47,569	47,495	47,418
+.Berks County, Pennsylvania	428,840	428,631	429,612	430,449
+.Blair County, Pennsylvania	122,820	122,651	122,181	121,032
+.Bradford County, Pennsylvania	59,969	59,969	60,099	59,866
+.Bucks County, Pennsylvania	646,526	646,112	647,159	645,054
+.Butler County, Pennsylvania	193,767	194,056	196,789	197,300
+.Cambria County, Pennsylvania	133,477	133,199	132,281	131,441
+.Cameron County, Pennsylvania	4,546	4,531	4,461	4,418
+.Carbon County, Pennsylvania	64,750	64,744	65,460	65,460
+.Centre County, Pennsylvania	158,163	157,962	157,990	158,425
+.Chester County, Pennsylvania	534,408	534,783	540,864	545,823
+.Clarion County, Pennsylvania	37,236	37,193	37,581	37,346
+.Clearfield County, Pennsylvania	80,564	80,438	78,333	77,904
+.Clinton County, Pennsylvania	37,456	37,380	38,035	37,931
+.Columbia County, Pennsylvania	64,725	64,682	64,980	64,926
+.Crawford County, Pennsylvania	83,937	83,797	83,202	82,670
+.Cumberland County, Pennsylvania	259,464	260,223	265,593	268,579
+.Dauphin County, Pennsylvania	286,399	286,685	288,187	288,800
+.Delaware County, Pennsylvania	576,842	576,323	576,772	575,182
+.Elk County, Pennsylvania	30,984	30,926	30,771	30,477
+.Erie County, Pennsylvania	270,869	270,539	269,300	267,689
+.Fayette County, Pennsylvania	128,816	128,569	127,113	125,755
+.Forest County, Pennsylvania	6,974	6,959	6,896	6,626
+.Franklin County, Pennsylvania	155,950	155,939	156,589	156,902
+.Fulton County, Pennsylvania	14,559	14,572	14,509	14,533
+.Greene County, Pennsylvania	35,946	35,859	35,269	34,663
+.Huntingdon County, Pennsylvania	44,094	44,047	43,937	43,281
+.Indiana County, Pennsylvania	83,231	83,142	83,158	82,957
+.Jefferson County, Pennsylvania	44,496	44,478	44,142	43,794
+.Juniata County, Pennsylvania	23,496	23,471	23,348	23,339
+.Lackawanna County, Pennsylvania	215,911	215,523	215,957	215,615
+.Lancaster County, Pennsylvania	552,969	552,761	556,049	556,629
+.Lawrence County, Pennsylvania	86,069	85,959	85,554	84,849
+.Lebanon County, Pennsylvania	143,262	143,282	143,809	144,011
+.Lehigh County, Pennsylvania	374,572	374,477	375,760	376,317
+.Luzerne County, Pennsylvania	325,613	325,197	325,889	326,369
+.Lycoming County, Pennsylvania	114,182	114,108	113,595	113,104
+.McKean County, Pennsylvania	40,426	40,392	40,292	39,866
+.Mercer County, Pennsylvania	110,656	110,534	109,950	109,220
+.Mifflin County, Pennsylvania	46,145	46,144	46,187	45,988
+.Monroe County, Pennsylvania	168,323	168,316	168,629	167,198
+.Montgomery County, Pennsylvania	856,559	856,938	864,022	864,683
+.Montour County, Pennsylvania	18,145	18,129	18,103	18,091
+.Northampton County, Pennsylvania	312,955	312,774	318,051	318,526
+.Northumberland County, Pennsylvania	91,647	91,542	91,013	90,133
+.Perry County, Pennsylvania	45,837	45,828	45,941	46,114
+.Philadelphia County, Pennsylvania	1,603,799	1,600,600	1,589,480	1,567,258
+.Pike County, Pennsylvania	58,537	58,560	59,965	60,558
+.Potter County, Pennsylvania	16,401	16,385	16,287	16,220
+.Schuylkill County, Pennsylvania	143,048	142,946	143,201	143,104
+.Snyder County, Pennsylvania	39,735	39,727	39,742	39,652
+.Somerset County, Pennsylvania	74,147	74,016	72,999	72,710
+.Sullivan County, Pennsylvania	5,832	5,823	5,859	5,855
+.Susquehanna County, Pennsylvania	38,423	38,334	38,363	38,074
+.Tioga County, Pennsylvania	41,046	41,014	41,335	41,106
+.Union County, Pennsylvania	42,675	42,639	42,419	42,744
+.Venango County, Pennsylvania	50,455	50,354	50,038	49,777
+.Warren County, Pennsylvania	38,594	38,516	38,115	37,808
+.Washington County, Pennsylvania	209,325	209,382	210,012	210,383
+.Wayne County, Pennsylvania	51,151	51,151	51,195	51,173
+.Westmoreland County, Pennsylvania	354,663	354,316	353,765	352,057
+.Wyoming County, Pennsylvania	26,073	26,030	26,100	26,014
+.York County, Pennsylvania	456,442	456,692	459,148	461,058
+.Bristol County, Rhode Island	50,786	50,774	50,800	50,360
+.Kent County, Rhode Island	170,358	170,386	170,997	171,275
+.Newport County, Rhode Island	85,652	85,508	85,662	84,481
+.Providence County, Rhode Island	660,739	659,920	658,646	657,288
+.Washington County, Rhode Island	129,836	129,757	130,880	130,330
+.Abbeville County, South Carolina	24,287	24,256	24,258	24,356
+.Aiken County, South Carolina	168,811	169,163	171,263	174,150
+.Allendale County, South Carolina	8,037	7,992	7,870	7,579
+.Anderson County, South Carolina	203,723	204,176	206,852	209,581
+.Bamberg County, South Carolina	13,313	13,261	13,112	12,908
+.Barnwell County, South Carolina	20,585	20,580	20,580	20,414
+.Beaufort County, South Carolina	187,108	187,819	192,007	196,371
+.Berkeley County, South Carolina	229,854	231,538	236,871	245,117
+.Calhoun County, South Carolina	14,122	14,113	14,134	14,179
+.Charleston County, South Carolina	408,317	409,716	414,403	419,279
+.Cherokee County, South Carolina	56,216	56,207	56,025	56,121
+.Chester County, South Carolina	32,294	32,278	32,097	31,931
+.Chesterfield County, South Carolina	43,270	43,250	43,337	43,683
+.Clarendon County, South Carolina	31,148	30,835	30,950	30,913
+.Colleton County, South Carolina	38,604	38,536	38,427	38,599
+.Darlington County, South Carolina	62,907	62,843	62,708	62,398
+.Dillon County, South Carolina	28,295	28,275	27,981	27,738
+.Dorchester County, South Carolina	161,469	162,159	163,508	166,133
+.Edgefield County, South Carolina	25,648	25,672	26,285	26,932
+.Fairfield County, South Carolina	20,951	20,880	20,698	20,455
+.Florence County, South Carolina	137,064	136,811	136,439	136,721
+.Georgetown County, South Carolina	63,402	63,506	63,991	64,722
+.Greenville County, South Carolina	525,539	527,207	534,521	547,950
+.Greenwood County, South Carolina	69,349	69,388	69,148	69,267
+.Hampton County, South Carolina	18,561	18,519	18,236	18,113
+.Horry County, South Carolina	351,028	353,745	366,011	383,101
+.Jasper County, South Carolina	28,806	29,143	30,456	32,039
+.Kershaw County, South Carolina	65,407	65,581	66,121	67,751
+.Lancaster County, South Carolina	96,010	96,576	100,522	104,577
+.Laurens County, South Carolina	67,533	67,624	67,817	67,965
+.Lee County, South Carolina	16,530	16,533	16,266	16,153
+.Lexington County, South Carolina	293,985	295,033	300,482	304,797
+.McCormick County, South Carolina	9,522	9,505	9,782	9,764
+.Marion County, South Carolina	29,187	29,083	28,839	28,450
+.Marlboro County, South Carolina	26,668	26,481	26,265	26,039
+.Newberry County, South Carolina	37,722	37,731	37,957	38,247
+.Oconee County, South Carolina	78,604	78,778	79,322	80,180
+.Orangeburg County, South Carolina	84,225	83,956	82,798	83,094
+.Pickens County, South Carolina	131,401	131,669	132,079	133,462
+.Richland County, South Carolina	416,145	415,645	417,132	421,566
+.Saluda County, South Carolina	18,859	18,830	18,821	18,938
+.Spartanburg County, South Carolina	328,002	329,365	335,406	345,831
+.Sumter County, South Carolina	105,554	105,474	104,856	104,012
+.Union County, South Carolina	27,240	27,176	26,994	26,752
+.Williamsburg County, South Carolina	31,019	30,908	30,384	30,058
+.York County, South Carolina	282,108	284,032	289,255	294,248
+.Aurora County, South Dakota	2,746	2,733	2,732	2,755
+.Beadle County, South Dakota	19,153	19,165	19,182	19,376
+.Bennett County, South Dakota	3,378	3,389	3,400	3,336
+.Bon Homme County, South Dakota	6,997	6,973	7,011	7,062
+.Brookings County, South Dakota	34,380	34,350	34,710	35,484
+.Brown County, South Dakota	38,301	38,222	38,090	37,972
+.Brule County, South Dakota	5,253	5,253	5,254	5,321
+.Buffalo County, South Dakota	1,945	1,938	1,912	1,861
+.Butte County, South Dakota	10,238	10,286	10,530	10,774
+.Campbell County, South Dakota	1,375	1,377	1,375	1,349
+.Charles Mix County, South Dakota	9,370	9,356	9,186	9,213
+.Clark County, South Dakota	3,844	3,855	3,867	3,912
+.Clay County, South Dakota	14,966	14,996	15,155	15,280
+.Codington County, South Dakota	28,323	28,350	28,467	28,721
+.Corson County, South Dakota	3,901	3,891	3,843	3,826
+.Custer County, South Dakota	8,319	8,334	8,635	9,006
+.Davison County, South Dakota	19,960	19,962	19,926	19,973
+.Day County, South Dakota	5,451	5,442	5,435	5,479
+.Deuel County, South Dakota	4,293	4,294	4,280	4,352
+.Dewey County, South Dakota	5,242	5,224	5,218	5,140
+.Douglas County, South Dakota	2,828	2,829	2,809	2,776
+.Edmunds County, South Dakota	3,981	3,982	4,028	4,065
+.Fall River County, South Dakota	6,971	6,972	7,189	7,370
+.Faulk County, South Dakota	2,126	2,128	2,126	2,126
+.Grant County, South Dakota	7,556	7,532	7,532	7,463
+.Gregory County, South Dakota	3,991	3,997	3,952	3,962
+.Haakon County, South Dakota	1,876	1,870	1,834	1,826
+.Hamlin County, South Dakota	6,159	6,157	6,263	6,352
+.Hand County, South Dakota	3,146	3,145	3,095	3,140
+.Hanson County, South Dakota	3,462	3,465	3,496	3,461
+.Harding County, South Dakota	1,309	1,307	1,320	1,330
+.Hughes County, South Dakota	17,774	17,745	17,768	17,692
+.Hutchinson County, South Dakota	7,423	7,421	7,400	7,368
+.Hyde County, South Dakota	1,260	1,249	1,215	1,184
+.Jackson County, South Dakota	2,807	2,801	2,846	2,821
+.Jerauld County, South Dakota	1,663	1,648	1,640	1,650
+.Jones County, South Dakota	919	925	884	884
+.Kingsbury County, South Dakota	5,184	5,203	5,201	5,294
+.Lake County, South Dakota	11,057	11,008	10,863	10,972
+.Lawrence County, South Dakota	25,766	25,838	26,138	27,214
+.Lincoln County, South Dakota	65,165	65,650	67,995	70,987
+.Lyman County, South Dakota	3,722	3,709	3,753	3,692
+.McCook County, South Dakota	5,682	5,673	5,723	5,778
+.McPherson County, South Dakota	2,409	2,402	2,414	2,395
+.Marshall County, South Dakota	4,317	4,315	4,319	4,374
+.Meade County, South Dakota	29,851	29,900	30,270	30,698
+.Mellette County, South Dakota	1,920	1,921	1,908	1,892
+.Miner County, South Dakota	2,307	2,310	2,329	2,304
+.Minnehaha County, South Dakota	197,209	197,686	199,925	203,971
+.Moody County, South Dakota	6,340	6,343	6,314	6,349
+.Oglala Lakota County, South Dakota	13,669	13,645	13,549	13,519
+.Pennington County, South Dakota	109,231	109,563	111,854	114,461
+.Perkins County, South Dakota	2,842	2,842	2,823	2,804
+.Potter County, South Dakota	2,480	2,480	2,471	2,438
+.Roberts County, South Dakota	10,271	10,250	10,178	10,163
+.Sanborn County, South Dakota	2,330	2,325	2,383	2,415
+.Spink County, South Dakota	6,362	6,347	6,273	6,235
+.Stanley County, South Dakota	2,980	2,969	3,017	2,999
+.Sully County, South Dakota	1,448	1,452	1,471	1,471
+.Todd County, South Dakota	9,319	9,317	9,292	9,220
+.Tripp County, South Dakota	5,621	5,603	5,566	5,565
+.Turner County, South Dakota	8,662	8,672	8,682	8,856
+.Union County, South Dakota	16,813	16,853	16,868	17,063
+.Walworth County, South Dakota	5,310	5,286	5,246	5,265
+.Yankton County, South Dakota	23,311	23,282	23,334	23,373
+.Ziebach County, South Dakota	2,413	2,392	2,400	2,395
+.Anderson County, Tennessee	77,136	77,302	77,567	78,913
+.Bedford County, Tennessee	50,239	50,381	51,157	51,950
+.Benton County, Tennessee	15,863	15,850	15,839	16,002
+.Bledsoe County, Tennessee	14,916	14,954	14,844	14,798
+.Blount County, Tennessee	135,283	135,649	137,649	139,958
+.Bradley County, Tennessee	108,620	108,820	109,769	110,616
+.Campbell County, Tennessee	39,277	39,301	39,409	39,584
+.Cannon County, Tennessee	14,512	14,568	14,535	14,788
+.Carroll County, Tennessee	28,434	28,421	28,287	28,458
+.Carter County, Tennessee	56,349	56,362	56,060	56,410
+.Cheatham County, Tennessee	41,065	41,128	41,547	41,830
+.Chester County, Tennessee	17,348	17,377	17,479	17,609
+.Claiborne County, Tennessee	32,038	32,066	32,146	32,431
+.Clay County, Tennessee	7,580	7,588	7,572	7,620
+.Cocke County, Tennessee	35,998	36,039	36,370	36,879
+.Coffee County, Tennessee	57,882	58,134	58,933	59,728
+.Crockett County, Tennessee	13,909	13,903	13,993	13,888
+.Cumberland County, Tennessee	61,152	61,377	62,431	63,522
+.Davidson County, Tennessee	715,875	716,058	703,372	708,144
+.Decatur County, Tennessee	11,442	11,437	11,413	11,564
+.DeKalb County, Tennessee	20,078	20,187	20,478	21,003
+.Dickson County, Tennessee	54,314	54,442	55,174	55,761
+.Dyer County, Tennessee	36,803	36,709	36,586	36,410
+.Fayette County, Tennessee	42,002	42,151	42,899	43,630
+.Fentress County, Tennessee	18,489	18,533	18,837	19,332
+.Franklin County, Tennessee	42,769	42,839	43,247	43,942
+.Gibson County, Tennessee	50,409	50,436	50,537	50,837
+.Giles County, Tennessee	30,344	30,340	30,403	30,554
+.Grainger County, Tennessee	23,527	23,563	23,833	24,277
+.Greene County, Tennessee	70,152	70,333	70,603	71,405
+.Grundy County, Tennessee	13,525	13,539	13,586	13,783
+.Hamblen County, Tennessee	64,500	64,537	64,390	65,168
+.Hamilton County, Tennessee	366,215	367,242	369,027	374,682
+.Hancock County, Tennessee	6,659	6,625	6,777	6,845
+.Hardeman County, Tennessee	25,460	25,432	25,276	25,529
+.Hardin County, Tennessee	26,829	26,805	26,878	27,077
+.Hawkins County, Tennessee	56,718	56,710	57,257	58,043
+.Haywood County, Tennessee	17,862	17,824	17,715	17,550
+.Henderson County, Tennessee	27,841	27,827	27,916	27,929
+.Henry County, Tennessee	32,197	32,144	32,250	32,379
+.Hickman County, Tennessee	24,909	24,969	25,085	25,455
+.Houston County, Tennessee	8,281	8,303	8,282	8,219
+.Humphreys County, Tennessee	18,992	19,001	19,200	19,106
+.Jackson County, Tennessee	11,619	11,634	11,777	11,989
+.Jefferson County, Tennessee	54,679	54,908	55,562	56,727
+.Johnson County, Tennessee	17,950	17,990	18,056	18,086
+.Knox County, Tennessee	478,981	480,500	486,812	494,574
+.Lake County, Tennessee	7,004	6,988	6,597	6,507
+.Lauderdale County, Tennessee	25,139	25,120	24,922	24,793
+.Lawrence County, Tennessee	44,163	44,182	44,729	45,415
+.Lewis County, Tennessee	12,581	12,602	12,854	12,957
+.Lincoln County, Tennessee	35,326	35,335	35,451	36,004
+.Loudon County, Tennessee	54,887	55,127	56,672	58,181
+.McMinn County, Tennessee	53,275	53,344	53,907	54,719
+.McNairy County, Tennessee	25,859	25,858	25,854	25,988
+.Macon County, Tennessee	25,215	25,263	25,682	26,229
+.Madison County, Tennessee	98,843	98,833	98,585	99,245
+.Marion County, Tennessee	28,835	28,865	28,927	29,094
+.Marshall County, Tennessee	34,320	34,466	35,032	35,878
+.Maury County, Tennessee	100,975	101,824	105,003	108,159
+.Meigs County, Tennessee	12,755	12,807	13,029	13,272
+.Monroe County, Tennessee	46,249	46,395	46,668	47,740
+.Montgomery County, Tennessee	219,994	221,265	227,841	235,201
+.Moore County, Tennessee	6,469	6,471	6,652	6,742
+.Morgan County, Tennessee	21,027	21,038	21,101	21,224
+.Obion County, Tennessee	30,788	30,767	30,498	30,394
+.Overton County, Tennessee	22,514	22,592	22,856	23,044
+.Perry County, Tennessee	8,381	8,379	8,473	8,685
+.Pickett County, Tennessee	5,006	5,002	5,082	5,107
+.Polk County, Tennessee	17,547	17,568	17,784	17,863
+.Putnam County, Tennessee	79,844	80,052	81,255	82,382
+.Rhea County, Tennessee	32,870	32,934	33,205	33,730
+.Roane County, Tennessee	53,393	53,510	54,056	55,082
+.Robertson County, Tennessee	72,803	72,945	74,088	75,470
+.Rutherford County, Tennessee	341,481	343,266	351,202	360,619
+.Scott County, Tennessee	21,852	21,878	21,895	22,035
+.Sequatchie County, Tennessee	15,829	15,850	16,445	16,909
+.Sevier County, Tennessee	98,391	98,562	99,435	98,789
+.Shelby County, Tennessee	929,722	929,388	923,352	916,371
+.Smith County, Tennessee	19,914	19,970	20,181	20,489
+.Stewart County, Tennessee	13,662	13,711	13,830	14,035
+.Sullivan County, Tennessee	158,161	158,237	159,167	160,820
+.Sumner County, Tennessee	196,281	197,396	200,582	203,858
+.Tipton County, Tennessee	60,979	61,041	61,049	61,656
+.Trousdale County, Tennessee	11,610	11,638	11,619	12,111
+.Unicoi County, Tennessee	17,924	17,883	17,667	17,674
+.Union County, Tennessee	19,802	19,841	19,996	20,452
+.Van Buren County, Tennessee	6,168	6,174	6,277	6,429
+.Warren County, Tennessee	40,951	41,054	41,529	42,026
+.Washington County, Tennessee	133,005	133,213	133,525	136,172
+.Wayne County, Tennessee	16,232	16,222	16,336	16,308
+.Weakley County, Tennessee	32,902	32,899	32,870	33,063
+.White County, Tennessee	27,356	27,443	27,557	28,064
+.Williamson County, Tennessee	247,733	249,538	256,209	260,815
+.Wilson County, Tennessee	147,747	148,645	152,010	158,555
+.Anderson County, Texas	57,922	57,926	58,233	58,064
+.Andrews County, Texas	18,614	18,617	18,411	18,334
+.Angelina County, Texas	86,394	86,376	86,654	87,101
+.Aransas County, Texas	23,831	23,932	24,519	24,944
+.Archer County, Texas	8,554	8,554	8,684	8,835
+.Armstrong County, Texas	1,846	1,849	1,838	1,850
+.Atascosa County, Texas	48,985	49,134	49,886	50,864
+.Austin County, Texas	30,168	30,131	30,421	31,097
+.Bailey County, Texas	6,904	6,868	6,803	6,779
+.Bandera County, Texas	20,843	20,992	21,551	22,115
+.Bastrop County, Texas	97,218	98,046	102,166	106,188
+.Baylor County, Texas	3,465	3,461	3,456	3,466
+.Bee County, Texas	31,061	31,049	30,828	30,394
+.Bell County, Texas	370,644	372,229	380,241	388,386
+.Bexar County, Texas	2,009,322	2,015,369	2,030,895	2,059,530
+.Blanco County, Texas	11,376	11,450	11,890	12,418
+.Borden County, Texas	628	641	621	585
+.Bosque County, Texas	18,226	18,245	18,495	18,697
+.Bowie County, Texas	92,903	92,924	92,291	92,035
+.Brazoria County, Texas	372,040	373,481	378,858	388,181
+.Brazos County, Texas	233,848	234,486	237,583	242,014
+.Brewster County, Texas	9,545	9,553	9,459	9,343
+.Briscoe County, Texas	1,434	1,419	1,400	1,431
+.Brooks County, Texas	7,086	7,057	6,994	6,906
+.Brown County, Texas	38,101	38,048	38,142	38,373
+.Burleson County, Texas	17,642	17,680	18,110	18,657
+.Burnet County, Texas	49,123	49,473	51,080	52,502
+.Caldwell County, Texas	45,887	45,949	46,904	47,848
+.Calhoun County, Texas	20,105	20,063	19,798	19,706
+.Callahan County, Texas	13,703	13,744	14,078	14,210
+.Cameron County, Texas	421,012	421,445	423,124	425,208
+.Camp County, Texas	12,465	12,427	12,594	12,716
+.Carson County, Texas	5,799	5,791	5,708	5,784
+.Cass County, Texas	28,445	28,436	28,557	28,539
+.Castro County, Texas	7,376	7,336	7,362	7,298
+.Chambers County, Texas	46,571	47,025	48,721	51,288
+.Cherokee County, Texas	50,411	50,488	51,163	51,645
+.Childress County, Texas	6,666	6,662	6,781	6,809
+.Clay County, Texas	10,213	10,250	10,315	10,486
+.Cochran County, Texas	2,543	2,557	2,491	2,526
+.Coke County, Texas	3,280	3,295	3,313	3,333
+.Coleman County, Texas	7,686	7,686	7,736	7,850
+.Collin County, Texas	1,066,465	1,075,654	1,114,450	1,158,696
+.Collingsworth County, Texas	2,648	2,638	2,603	2,568
+.Colorado County, Texas	20,555	20,558	20,592	20,754
+.Comal County, Texas	161,482	163,640	174,891	184,642
+.Comanche County, Texas	13,590	13,628	13,804	13,878
+.Concho County, Texas	3,303	3,303	3,336	3,340
+.Cooke County, Texas	41,671	41,744	42,408	43,050
+.Coryell County, Texas	83,091	83,146	84,406	85,057
+.Cottle County, Texas	1,380	1,364	1,357	1,307
+.Crane County, Texas	4,676	4,673	4,639	4,546
+.Crockett County, Texas	3,097	3,094	3,015	2,943
+.Crosby County, Texas	5,125	5,093	5,085	4,998
+.Culberson County, Texas	2,188	2,185	2,182	2,155
+.Dallam County, Texas	7,121	7,126	7,188	7,241
+.Dallas County, Texas	2,611,491	2,609,966	2,587,954	2,600,840
+.Dawson County, Texas	12,457	12,473	12,412	12,130
+.Deaf Smith County, Texas	18,585	18,526	18,345	18,377
+.Delta County, Texas	5,225	5,222	5,337	5,406
+.Denton County, Texas	906,405	914,324	943,857	977,281
+.DeWitt County, Texas	19,822	19,835	19,949	19,772
+.Dickens County, Texas	1,769	1,758	1,734	1,726
+.Dimmit County, Texas	8,611	8,577	8,479	8,387
+.Donley County, Texas	3,261	3,279	3,364	3,339
+.Duval County, Texas	9,827	9,807	10,003	9,888
+.Eastland County, Texas	17,733	17,775	17,834	17,944
+.Ector County, Texas	165,171	165,485	160,764	160,869
+.Edwards County, Texas	1,427	1,424	1,431	1,422
+.Ellis County, Texas	192,441	194,295	203,107	212,182
+.El Paso County, Texas	865,655	866,547	868,086	868,763
+.Erath County, Texas	42,545	42,716	43,389	43,895
+.Falls County, Texas	16,963	16,954	17,099	17,049
+.Fannin County, Texas	35,661	35,798	36,716	37,125
+.Fayette County, Texas	24,436	24,471	24,669	24,913
+.Fisher County, Texas	3,671	3,676	3,678	3,622
+.Floyd County, Texas	5,397	5,368	5,299	5,235
+.Foard County, Texas	1,092	1,085	1,052	1,057
+.Fort Bend County, Texas	822,779	829,036	860,124	889,146
+.Franklin County, Texas	10,357	10,371	10,472	10,618
+.Freestone County, Texas	19,445	19,445	19,784	19,950
+.Frio County, Texas	18,392	18,409	17,548	17,815
+.Gaines County, Texas	21,599	21,699	21,881	22,181
+.Galveston County, Texas	350,673	351,559	355,309	357,117
+.Garza County, Texas	5,816	5,817	6,269	6,262
+.Gillespie County, Texas	26,722	26,742	27,282	27,477
+.Glasscock County, Texas	1,115	1,117	1,142	1,164
+.Goliad County, Texas	7,018	7,021	7,146	7,131
+.Gonzales County, Texas	19,657	19,679	19,655	19,832
+.Gray County, Texas	21,229	21,198	21,085	21,015
+.Grayson County, Texas	135,552	136,100	139,561	143,131
+.Gregg County, Texas	124,234	124,241	124,052	125,443
+.Grimes County, Texas	29,292	29,430	30,106	30,754
+.Guadalupe County, Texas	172,709	173,686	177,254	182,760
+.Hale County, Texas	32,526	32,465	32,234	31,827
+.Hall County, Texas	2,817	2,797	2,845	2,810
+.Hamilton County, Texas	8,221	8,247	8,238	8,298
+.Hansford County, Texas	5,281	5,260	5,138	5,151
+.Hardeman County, Texas	3,549	3,559	3,544	3,516
+.Hardin County, Texas	56,234	56,344	57,044	57,811
+.Harris County, Texas	4,731,129	4,734,505	4,735,287	4,780,913
+.Harrison County, Texas	68,834	68,798	69,454	69,955
+.Hartley County, Texas	5,376	5,349	5,389	5,208
+.Haskell County, Texas	5,412	5,432	5,392	5,403
+.Hays County, Texas	241,066	243,967	256,065	269,225
+.Hemphill County, Texas	3,383	3,363	3,315	3,217
+.Henderson County, Texas	82,145	82,394	83,590	84,511
+.Hidalgo County, Texas	870,796	872,806	880,633	888,367
+.Hill County, Texas	35,869	35,962	36,430	37,329
+.Hockley County, Texas	21,543	21,503	21,256	21,161
+.Hood County, Texas	61,597	62,054	64,263	66,373
+.Hopkins County, Texas	36,792	36,824	37,237	37,804
+.Houston County, Texas	22,067	22,055	21,958	21,950
+.Howard County, Texas	34,864	34,812	34,336	33,672
+.Hudspeth County, Texas	3,206	3,203	3,289	3,432
+.Hunt County, Texas	99,957	100,257	103,458	108,282
+.Hutchinson County, Texas	20,614	20,568	20,411	20,215
+.Irion County, Texas	1,513	1,511	1,531	1,530
+.Jack County, Texas	8,474	8,486	8,718	8,922
+.Jackson County, Texas	14,987	14,992	15,097	15,142
+.Jasper County, Texas	32,983	32,921	32,570	32,484
+.Jeff Davis County, Texas	2,000	1,986	1,959	1,903
+.Jefferson County, Texas	256,526	256,118	253,531	250,830
+.Jim Hogg County, Texas	4,835	4,846	4,797	4,763
+.Jim Wells County, Texas	38,893	38,877	38,923	38,826
+.Johnson County, Texas	179,999	180,945	187,442	195,506
+.Jones County, Texas	19,653	19,678	19,809	19,935
+.Karnes County, Texas	14,707	14,763	14,714	14,836
+.Kaufman County, Texas	145,303	147,126	158,216	172,366
+.Kendall County, Texas	44,281	44,547	46,851	48,973
+.Kenedy County, Texas	352	351	342	358
+.Kent County, Texas	753	761	746	740
+.Kerr County, Texas	52,594	52,691	53,136	53,741
+.Kimble County, Texas	4,280	4,291	4,350	4,422
+.King County, Texas	262	266	256	233
+.Kinney County, Texas	3,131	3,124	3,117	3,128
+.Kleberg County, Texas	31,038	30,977	30,642	30,362
+.Knox County, Texas	3,353	3,346	3,307	3,273
+.Lamar County, Texas	50,082	50,126	50,305	50,484
+.Lamb County, Texas	13,043	13,005	12,886	12,724
+.Lampasas County, Texas	21,632	21,707	22,213	22,785
+.La Salle County, Texas	6,667	6,664	6,716	6,604
+.Lavaca County, Texas	20,337	20,348	20,490	20,589
+.Lee County, Texas	17,480	17,502	17,671	17,954
+.Leon County, Texas	15,717	15,731	15,985	16,209
+.Liberty County, Texas	91,632	92,465	97,382	101,992
+.Limestone County, Texas	22,147	22,139	22,125	22,253
+.Lipscomb County, Texas	3,058	3,036	2,907	2,854
+.Live Oak County, Texas	11,333	11,349	11,383	11,428
+.Llano County, Texas	21,243	21,285	22,013	22,540
+.Loving County, Texas	63	65	57	51
+.Lubbock County, Texas	310,642	311,564	314,597	317,561
+.Lynn County, Texas	5,595	5,610	5,652	5,724
+.McCulloch County, Texas	7,634	7,591	7,532	7,497
+.McLennan County, Texas	260,582	261,177	263,714	266,836
+.McMullen County, Texas	600	598	597	576
+.Madison County, Texas	13,463	13,464	13,498	13,661
+.Marion County, Texas	9,728	9,751	9,618	9,560
+.Martin County, Texas	5,239	5,252	5,208	5,217
+.Mason County, Texas	3,951	3,968	3,929	3,982
+.Matagorda County, Texas	36,249	36,280	36,366	36,125
+.Maverick County, Texas	57,885	57,873	57,841	57,843
+.Medina County, Texas	50,739	50,939	52,322	53,723
+.Menard County, Texas	1,964	1,961	1,964	1,968
+.Midland County, Texas	169,984	170,348	168,206	171,999
+.Milam County, Texas	24,750	24,775	25,189	25,628
+.Mills County, Texas	4,454	4,447	4,497	4,500
+.Mitchell County, Texas	8,991	9,014	9,050	8,943
+.Montague County, Texas	19,965	19,994	20,430	21,063
+.Montgomery County, Texas	620,451	625,243	650,261	678,490
+.Moore County, Texas	21,362	21,264	21,122	20,996
+.Morris County, Texas	11,971	11,972	12,009	12,083
+.Motley County, Texas	1,063	1,063	1,065	1,032
+.Nacogdoches County, Texas	64,651	64,619	64,699	64,862
+.Navarro County, Texas	52,623	52,828	53,616	54,636
+.Newton County, Texas	12,216	12,157	12,202	12,052
+.Nolan County, Texas	14,736	14,723	14,600	14,473
+.Nueces County, Texas	353,170	353,376	353,230	351,674
+.Ochiltree County, Texas	10,015	9,954	9,763	9,606
+.Oldham County, Texas	1,759	1,764	1,730	1,752
+.Orange County, Texas	84,806	84,747	84,641	84,934
+.Palo Pinto County, Texas	28,408	28,445	28,676	29,239
+.Panola County, Texas	22,492	22,492	22,538	22,677
+.Parker County, Texas	148,228	149,547	156,966	165,834
+.Parmer County, Texas	9,871	9,854	9,779	9,620
+.Pecos County, Texas	15,197	15,185	15,126	14,735
+.Polk County, Texas	50,119	50,494	51,816	53,255
+.Potter County, Texas	118,527	118,272	116,538	115,645
+.Presidio County, Texas	6,134	6,109	6,115	5,939
+.Rains County, Texas	12,154	12,178	12,449	12,823
+.Randall County, Texas	140,761	141,342	144,039	146,140
+.Reagan County, Texas	3,383	3,378	3,228	3,135
+.Real County, Texas	2,751	2,743	2,806	2,840
+.Red River County, Texas	11,588	11,560	11,547	11,542
+.Reeves County, Texas	14,741	14,763	13,002	12,905
+.Refugio County, Texas	6,739	6,742	6,700	6,632
+.Roberts County, Texas	828	822	798	803
+.Robertson County, Texas	16,759	16,771	16,948	17,153
+.Rockwall County, Texas	107,832	109,136	116,549	123,208
+.Runnels County, Texas	9,899	9,919	9,886	9,859
+.Rusk County, Texas	52,223	52,257	53,071	53,333
+.Sabine County, Texas	9,892	9,888	9,989	10,048
+.San Augustine County, Texas	7,921	7,923	7,900	7,857
+.San Jacinto County, Texas	27,399	27,531	27,829	28,348
+.San Patricio County, Texas	68,754	68,838	69,701	69,954
+.San Saba County, Texas	5,720	5,722	5,824	5,824
+.Schleicher County, Texas	2,454	2,445	2,443	2,357
+.Scurry County, Texas	16,929	16,937	16,830	16,686
+.Shackelford County, Texas	3,102	3,105	3,177	3,186
+.Shelby County, Texas	24,022	23,927	23,962	24,008
+.Sherman County, Texas	2,780	2,787	2,791	2,799
+.Smith County, Texas	233,484	234,195	237,114	241,922
+.Somervell County, Texas	9,204	9,204	9,472	9,757
+.Starr County, Texas	65,918	65,861	65,972	65,728
+.Stephens County, Texas	9,104	9,098	9,434	9,390
+.Sterling County, Texas	1,369	1,381	1,382	1,417
+.Stonewall County, Texas	1,246	1,245	1,208	1,182
+.Sutton County, Texas	3,372	3,355	3,284	3,217
+.Swisher County, Texas	6,971	6,946	6,996	6,881
+.Tarrant County, Texas	2,110,608	2,115,682	2,129,402	2,154,595
+.Taylor County, Texas	143,205	143,444	143,942	145,163
+.Terrell County, Texas	760	750	720	693
+.Terry County, Texas	11,832	11,794	11,721	11,567
+.Throckmorton County, Texas	1,442	1,453	1,508	1,550
+.Titus County, Texas	31,245	31,292	31,266	31,208
+.Tom Green County, Texas	120,007	120,194	119,250	118,892
+.Travis County, Texas	1,290,209	1,296,515	1,308,544	1,326,436
+.Trinity County, Texas	13,600	13,632	13,809	13,996
+.Tyler County, Texas	19,799	19,811	19,892	20,030
+.Upshur County, Texas	40,890	41,038	41,811	42,488
+.Upton County, Texas	3,308	3,301	3,241	3,152
+.Uvalde County, Texas	24,564	24,559	24,810	24,940
+.Val Verde County, Texas	47,584	47,605	47,589	47,606
+.Van Zandt County, Texas	59,540	59,749	61,200	62,859
+.Victoria County, Texas	91,320	91,303	90,897	91,065
+.Walker County, Texas	76,402	76,544	78,322	78,870
+.Waller County, Texas	56,763	57,304	59,474	61,894
+.Ward County, Texas	11,648	11,680	11,111	10,964
+.Washington County, Texas	35,804	35,805	35,898	36,159
+.Webb County, Texas	267,110	267,345	267,633	267,780
+.Wharton County, Texas	41,574	41,564	41,697	41,824
+.Wheeler County, Texas	4,987	4,976	4,905	4,807
+.Wichita County, Texas	129,355	129,617	130,006	129,978
+.Wilbarger County, Texas	12,891	12,844	12,688	12,491
+.Willacy County, Texas	20,163	20,150	20,290	20,143
+.Williamson County, Texas	609,010	615,517	644,451	671,418
+.Wilson County, Texas	49,757	50,051	51,281	52,735
+.Winkler County, Texas	7,791	7,750	7,373	7,306
+.Wise County, Texas	68,632	68,943	71,888	74,895
+.Wood County, Texas	44,855	45,041	46,031	46,857
+.Yoakum County, Texas	7,695	7,675	7,559	7,451
+.Young County, Texas	17,867	17,847	17,911	17,962
+.Zapata County, Texas	13,888	13,874	13,893	13,849
+.Zavala County, Texas	9,670	9,662	9,487	9,377
+.Beaver County, Utah	7,074	7,087	7,203	7,327
+.Box Elder County, Utah	57,669	57,946	59,693	61,498
+.Cache County, Utah	133,159	133,624	137,429	140,173
+.Carbon County, Utah	20,418	20,488	20,361	20,571
+.Daggett County, Utah	936	952	977	1,014
+.Davis County, Utah	362,689	363,745	367,446	369,948
+.Duchesne County, Utah	19,603	19,617	19,806	20,161
+.Emery County, Utah	9,822	9,842	9,963	10,099
+.Garfield County, Utah	5,092	5,107	5,149	5,281
+.Grand County, Utah	9,669	9,677	9,665	9,769
+.Iron County, Utah	57,285	57,708	60,522	62,429
+.Juab County, Utah	11,778	11,818	12,192	12,567
+.Kane County, Utah	7,663	7,688	7,999	8,227
+.Millard County, Utah	12,977	13,049	13,175	13,330
+.Morgan County, Utah	12,294	12,381	12,667	12,832
+.Piute County, Utah	1,437	1,433	1,482	1,487
+.Rich County, Utah	2,510	2,500	2,581	2,628
+.Salt Lake County, Utah	1,185,236	1,186,921	1,186,440	1,186,257
+.San Juan County, Utah	14,510	14,517	14,476	14,359
+.Sanpete County, Utah	28,435	28,521	29,138	29,724
+.Sevier County, Utah	21,517	21,561	21,918	22,069
+.Summit County, Utah	42,364	42,482	43,168	43,036
+.Tooele County, Utah	72,697	73,338	76,734	79,934
+.Uintah County, Utah	35,613	35,671	36,232	37,141
+.Utah County, Utah	659,392	663,559	685,806	702,434
+.Wasatch County, Utah	34,791	35,063	36,260	36,619
+.Washington County, Utah	180,281	182,009	191,476	197,680
+.Wayne County, Utah	2,490	2,508	2,567	2,645
+.Weber County, Utah	262,213	262,973	266,588	269,561
+.Addison County, Vermont	37,359	37,343	37,444	37,578
+.Bennington County, Vermont	37,344	37,300	37,424	37,392
+.Caledonia County, Vermont	30,235	30,183	30,423	30,579
+.Chittenden County, Vermont	168,324	168,386	169,271	169,301
+.Essex County, Vermont	5,919	5,918	5,965	5,994
+.Franklin County, Vermont	49,949	50,040	50,433	50,731
+.Grand Isle County, Vermont	7,291	7,276	7,418	7,489
+.Lamoille County, Vermont	25,939	25,917	26,147	26,090
+.Orange County, Vermont	29,289	29,299	29,625	29,846
+.Orleans County, Vermont	27,402	27,404	27,601	27,666
+.Rutland County, Vermont	60,570	60,477	60,720	60,366
+.Washington County, Vermont	59,804	59,756	60,023	60,048
+.Windham County, Vermont	45,909	45,850	46,128	45,842
+.Windsor County, Vermont	57,751	57,744	58,350	58,142
+.Accomack County, Virginia	33,417	33,388	33,364	33,191
+.Albemarle County, Virginia	112,396	112,502	113,742	114,534
+.Alleghany County, Virginia	15,219	15,186	15,024	14,835
+.Amelia County, Virginia	13,262	13,268	13,337	13,455
+.Amherst County, Virginia	31,311	31,309	31,391	31,589
+.Appomattox County, Virginia	16,117	16,154	16,398	16,748
+.Arlington County, Virginia	238,644	238,799	233,574	234,000
+.Augusta County, Virginia	77,485	77,567	77,778	78,064
+.Bath County, Virginia	4,205	4,186	4,087	4,049
+.Bedford County, Virginia	79,465	79,553	80,287	80,848
+.Bland County, Virginia	6,274	6,257	6,179	6,148
+.Botetourt County, Virginia	33,593	33,637	33,977	34,135
+.Brunswick County, Virginia	15,850	15,824	15,979	15,921
+.Buchanan County, Virginia	20,348	20,249	19,861	19,352
+.Buckingham County, Virginia	16,830	16,826	16,940	16,982
+.Campbell County, Virginia	55,689	55,625	55,375	55,141
+.Caroline County, Virginia	30,886	30,924	31,402	31,957
+.Carroll County, Virginia	29,154	29,142	29,071	29,147
+.Charles City County, Virginia	6,770	6,744	6,631	6,605
+.Charlotte County, Virginia	11,533	11,541	11,522	11,475
+.Chesterfield County, Virginia	364,546	365,776	371,276	378,408
+.Clarke County, Virginia	14,787	14,813	14,916	15,266
+.Craig County, Virginia	4,895	4,878	4,876	4,847
+.Culpeper County, Virginia	52,554	52,766	53,785	54,381
+.Cumberland County, Virginia	9,677	9,666	9,696	9,746
+.Dickenson County, Virginia	14,129	14,074	13,852	13,725
+.Dinwiddie County, Virginia	27,940	27,888	27,999	28,161
+.Essex County, Virginia	10,598	10,595	10,552	10,630
+.Fairfax County, Virginia	1,150,305	1,148,558	1,141,645	1,138,331
+.Fauquier County, Virginia	72,956	72,990	74,022	74,664
+.Floyd County, Virginia	15,475	15,469	15,509	15,619
+.Fluvanna County, Virginia	27,247	27,285	27,797	28,159
+.Franklin County, Virginia	54,475	54,486	55,010	55,074
+.Frederick County, Virginia	91,421	91,865	94,014	95,051
+.Giles County, Virginia	16,792	16,785	16,584	16,453
+.Gloucester County, Virginia	38,716	38,718	39,131	39,493
+.Goochland County, Virginia	24,729	24,853	25,499	26,109
+.Grayson County, Virginia	15,335	15,278	15,330	15,343
+.Greene County, Virginia	20,554	20,606	21,028	21,107
+.Greensville County, Virginia	11,389	11,382	11,412	11,226
+.Halifax County, Virginia	34,022	33,920	33,758	33,644
+.Hanover County, Virginia	109,980	110,195	111,821	112,938
+.Henrico County, Virginia	334,389	334,344	333,867	333,962
+.Henry County, Virginia	50,949	50,846	50,296	49,906
+.Highland County, Virginia	2,233	2,241	2,241	2,301
+.Isle of Wight County, Virginia	38,610	38,702	39,393	40,151
+.James City County, Virginia	78,255	78,478	79,914	81,199
+.King and Queen County, Virginia	6,606	6,588	6,668	6,718
+.King George County, Virginia	26,722	26,822	27,522	27,856
+.King William County, Virginia	17,811	17,916	18,205	18,492
+.Lancaster County, Virginia	10,919	10,897	10,896	10,750
+.Lee County, Virginia	22,173	22,107	22,061	21,982
+.Loudoun County, Virginia	420,955	422,669	428,435	432,085
+.Louisa County, Virginia	37,603	37,798	39,032	40,116
+.Lunenburg County, Virginia	11,937	11,947	11,997	12,031
+.Madison County, Virginia	13,842	13,860	13,950	14,000
+.Mathews County, Virginia	8,535	8,520	8,545	8,490
+.Mecklenburg County, Virginia	30,315	30,278	30,300	30,508
+.Middlesex County, Virginia	10,626	10,616	10,772	10,943
+.Montgomery County, Virginia	99,717	99,561	98,835	98,915
+.Nelson County, Virginia	14,770	14,737	14,800	14,652
+.New Kent County, Virginia	22,942	23,119	23,979	24,986
+.Northampton County, Virginia	12,278	12,208	12,039	11,900
+.Northumberland County, Virginia	11,838	11,838	12,046	12,302
+.Nottoway County, Virginia	15,642	15,639	15,584	15,559
+.Orange County, Virginia	36,184	36,391	37,189	37,991
+.Page County, Virginia	23,708	23,687	23,801	23,750
+.Patrick County, Virginia	17,604	17,583	17,668	17,643
+.Pittsylvania County, Virginia	60,502	60,365	60,090	59,952
+.Powhatan County, Virginia	30,334	30,438	31,172	31,489
+.Prince Edward County, Virginia	21,846	21,898	21,957	21,927
+.Prince George County, Virginia	43,010	43,045	42,998	43,134
+.Prince William County, Virginia	482,198	482,790	485,205	486,943
+.Pulaski County, Virginia	33,800	33,804	33,808	33,706
+.Rappahannock County, Virginia	7,350	7,321	7,437	7,502
+.Richmond County, Virginia	8,920	8,919	9,049	9,080
+.Roanoke County, Virginia	96,936	96,922	96,751	96,914
+.Rockbridge County, Virginia	22,650	22,645	22,639	22,593
+.Rockingham County, Virginia	83,759	83,765	84,470	85,397
+.Russell County, Virginia	25,786	25,756	25,577	25,448
+.Scott County, Virginia	21,568	21,585	21,482	21,476
+.Shenandoah County, Virginia	44,192	44,263	44,829	44,968
+.Smyth County, Virginia	29,800	29,782	29,600	29,449
+.Southampton County, Virginia	18,001	17,952	18,037	17,932
+.Spotsylvania County, Virginia	140,094	140,594	143,957	146,688
+.Stafford County, Virginia	156,937	157,746	161,584	163,380
+.Surry County, Virginia	6,558	6,551	6,524	6,527
+.Sussex County, Virginia	10,831	10,789	10,812	10,680
+.Tazewell County, Virginia	40,439	40,405	40,057	39,821
+.Warren County, Virginia	40,724	40,786	40,957	41,440
+.Washington County, Virginia	53,934	53,889	53,793	53,958
+.Westmoreland County, Virginia	18,477	18,508	18,732	18,712
+.Wise County, Virginia	36,118	36,061	35,707	35,421
+.Wythe County, Virginia	28,285	28,312	28,200	28,111
+.York County, Virginia	70,055	70,228	71,176	71,341
+.Alexandria city, Virginia	159,461	159,125	155,203	155,525
+.Bristol city, Virginia	17,218	17,295	17,095	16,975
+.Buena Vista city, Virginia	6,641	6,621	6,615	6,591
+.Charlottesville city, Virginia	46,554	46,465	45,730	45,373
+.Chesapeake city, Virginia	249,415	249,803	251,739	252,488
+.Colonial Heights city, Virginia	18,171	18,187	18,218	18,294
+.Covington city, Virginia	5,744	5,742	5,731	5,679
+.Danville city, Virginia	42,592	42,577	42,376	42,229
+.Emporia city, Virginia	5,766	5,709	5,622	5,481
+.Fairfax city, Virginia	24,148	24,175	24,391	24,835
+.Falls Church city, Virginia	14,658	14,677	14,546	14,586
+.Franklin city, Virginia	8,179	8,149	8,128	8,247
+.Fredericksburg city, Virginia	27,979	27,995	28,458	28,757
+.Galax city, Virginia	6,725	6,714	6,659	6,730
+.Hampton city, Virginia	137,158	137,276	137,847	138,037
+.Harrisonburg city, Virginia	51,810	51,706	51,526	51,158
+.Hopewell city, Virginia	23,032	23,010	23,145	22,962
+.Lexington city, Virginia	7,317	7,321	7,433	7,457
+.Lynchburg city, Virginia	79,007	78,973	79,118	79,287
+.Manassas city, Virginia	42,773	42,692	42,765	42,642
+.Manassas Park city, Virginia	17,217	17,161	17,082	16,703
+.Martinsville city, Virginia	13,486	13,479	13,549	13,725
+.Newport News city, Virginia	186,243	186,033	184,764	184,306
+.Norfolk city, Virginia	238,001	237,738	235,025	232,995
+.Norton city, Virginia	3,696	3,680	3,631	3,609
+.Petersburg city, Virginia	33,457	33,388	33,367	33,394
+.Poquoson city, Virginia	12,455	12,472	12,609	12,582
+.Portsmouth city, Virginia	97,915	97,954	97,638	97,029
+.Radford city, Virginia	16,068	16,119	16,542	16,738
+.Richmond city, Virginia	226,618	227,008	227,602	229,395
+.Roanoke city, Virginia	100,015	99,883	98,744	97,847
+.Salem city, Virginia	25,347	25,399	25,354	25,523
+.Staunton city, Virginia	25,754	25,811	25,653	25,904
+.Suffolk city, Virginia	94,326	94,697	96,328	98,537
+.Virginia Beach city, Virginia	459,471	459,646	458,680	455,618
+.Waynesboro city, Virginia	22,195	22,276	22,596	22,808
+.Williamsburg city, Virginia	15,413	15,468	15,675	15,909
+.Winchester city, Virginia	28,122	28,009	28,115	27,936
+.Adams County, Washington	20,612	20,608	20,640	20,961
+.Asotin County, Washington	22,288	22,325	22,468	22,508
+.Benton County, Washington	206,875	207,413	210,585	212,791
+.Chelan County, Washington	79,078	79,228	79,775	79,926
+.Clallam County, Washington	77,160	77,357	78,442	77,805
+.Clark County, Washington	503,309	505,301	512,588	516,779
+.Columbia County, Washington	3,952	3,949	4,015	4,026
+.Cowlitz County, Washington	110,740	111,019	111,648	111,956
+.Douglas County, Washington	42,937	43,031	43,838	44,192
+.Ferry County, Washington	7,178	7,196	7,267	7,448
+.Franklin County, Washington	96,746	97,143	98,126	98,678
+.Garfield County, Washington	2,288	2,298	2,354	2,363
+.Grant County, Washington	99,120	99,427	100,440	101,311
+.Grays Harbor County, Washington	75,636	75,855	76,787	77,038
+.Island County, Washington	86,847	86,990	87,557	86,625
+.Jefferson County, Washington	32,975	33,063	33,561	33,589
+.King County, Washington	2,269,667	2,274,094	2,253,038	2,266,789
+.Kitsap County, Washington	275,605	275,802	276,591	277,673
+.Kittitas County, Washington	44,342	44,626	44,688	45,189
+.Klickitat County, Washington	22,734	22,816	23,178	23,271
+.Lewis County, Washington	82,152	82,556	84,575	85,370
+.Lincoln County, Washington	10,879	10,927	11,277	11,601
+.Mason County, Washington	65,722	66,029	67,229	68,166
+.Okanogan County, Washington	42,098	42,146	42,741	43,127
+.Pacific County, Washington	23,365	23,491	23,971	24,113
+.Pend Oreille County, Washington	13,404	13,506	13,906	14,179
+.Pierce County, Washington	921,137	923,524	927,199	927,380
+.San Juan County, Washington	17,789	17,827	18,615	18,662
+.Skagit County, Washington	129,515	129,884	130,933	131,179
+.Skamania County, Washington	12,033	12,033	12,207	12,460
+.Snohomish County, Washington	827,947	829,869	836,037	840,079
+.Spokane County, Washington	539,332	541,125	545,498	549,690
+.Stevens County, Washington	46,450	46,587	47,553	48,229
+.Thurston County, Washington	294,797	295,988	298,078	298,758
+.Wahkiakum County, Washington	4,419	4,443	4,579	4,688
+.Walla Walla County, Washington	62,586	62,619	62,158	61,890
+.Whatcom County, Washington	226,843	227,430	226,718	230,677
+.Whitman County, Washington	47,971	47,804	43,238	47,619
+.Yakima County, Washington	256,719	256,702	256,647	257,001
+.Barbour County, West Virginia	15,462	15,463	15,445	15,414
+.Berkeley County, West Virginia	122,078	122,691	126,194	129,490
+.Boone County, West Virginia	21,807	21,739	21,367	20,968
+.Braxton County, West Virginia	12,449	12,397	12,293	12,185
+.Brooke County, West Virginia	22,551	22,472	22,109	21,733
+.Cabell County, West Virginia	94,346	94,234	93,494	92,730
+.Calhoun County, West Virginia	6,228	6,199	6,165	6,068
+.Clay County, West Virginia	8,050	8,007	7,895	7,814
+.Doddridge County, West Virginia	7,808	7,787	7,739	7,698
+.Fayette County, West Virginia	40,485	40,425	40,083	39,487
+.Gilmer County, West Virginia	7,417	7,397	7,389	7,325
+.Grant County, West Virginia	10,975	10,988	11,009	10,968
+.Greenbrier County, West Virginia	32,979	32,895	32,698	32,435
+.Hampshire County, West Virginia	23,092	23,097	23,374	23,468
+.Hancock County, West Virginia	29,095	29,037	28,591	28,172
+.Hardy County, West Virginia	14,298	14,241	14,155	14,192
+.Harrison County, West Virginia	65,922	65,839	65,436	64,915
+.Jackson County, West Virginia	27,792	27,720	27,761	27,716
+.Jefferson County, West Virginia	57,707	57,783	58,520	58,979
+.Kanawha County, West Virginia	180,744	180,217	177,993	175,515
+.Lewis County, West Virginia	17,028	17,016	16,897	16,767
+.Lincoln County, West Virginia	20,459	20,363	20,191	19,901
+.Logan County, West Virginia	32,572	32,510	31,917	31,316
+.McDowell County, West Virginia	19,118	18,921	18,413	17,850
+.Marion County, West Virginia	56,211	56,230	56,117	55,952
+.Marshall County, West Virginia	30,589	30,497	30,208	29,752
+.Mason County, West Virginia	25,448	25,398	25,290	25,000
+.Mercer County, West Virginia	59,660	59,517	59,215	58,700
+.Mineral County, West Virginia	26,938	26,890	26,866	26,855
+.Mingo County, West Virginia	23,574	23,487	23,094	22,573
+.Monongalia County, West Virginia	105,822	105,905	106,487	106,869
+.Monroe County, West Virginia	12,375	12,380	12,383	12,296
+.Morgan County, West Virginia	17,067	17,087	17,280	17,430
+.Nicholas County, West Virginia	24,603	24,554	24,415	24,335
+.Ohio County, West Virginia	42,444	42,338	41,878	41,447
+.Pendleton County, West Virginia	6,145	6,132	6,078	6,011
+.Pleasants County, West Virginia	7,653	7,652	7,612	7,586
+.Pocahontas County, West Virginia	7,873	7,864	7,890	7,819
+.Preston County, West Virginia	34,214	34,187	34,270	34,172
+.Putnam County, West Virginia	57,435	57,432	57,355	57,015
+.Raleigh County, West Virginia	74,581	74,386	73,801	72,882
+.Randolph County, West Virginia	27,934	27,892	27,891	27,600
+.Ritchie County, West Virginia	8,450	8,426	8,388	8,207
+.Roane County, West Virginia	14,028	13,986	13,912	13,834
+.Summers County, West Virginia	11,968	11,939	11,892	11,762
+.Taylor County, West Virginia	16,701	16,684	16,483	16,342
+.Tucker County, West Virginia	6,765	6,753	6,675	6,568
+.Tyler County, West Virginia	8,311	8,296	8,243	8,183
+.Upshur County, West Virginia	23,817	23,813	23,820	23,712
+.Wayne County, West Virginia	38,983	38,864	38,533	37,998
+.Webster County, West Virginia	8,380	8,356	8,286	8,167
+.Wetzel County, West Virginia	14,441	14,392	14,195	14,025
+.Wirt County, West Virginia	5,196	5,186	5,059	5,091
+.Wood County, West Virginia	84,300	84,142	83,791	83,340
+.Wyoming County, West Virginia	21,387	21,317	20,991	20,527
+.Adams County, Wisconsin	20,646	20,675	20,795	21,226
+.Ashland County, Wisconsin	16,033	16,018	16,054	16,039
+.Barron County, Wisconsin	46,709	46,714	46,746	46,843
+.Bayfield County, Wisconsin	16,213	16,233	16,304	16,608
+.Brown County, Wisconsin	268,729	268,921	268,814	270,036
+.Buffalo County, Wisconsin	13,312	13,319	13,312	13,391
+.Burnett County, Wisconsin	16,526	16,579	16,759	17,036
+.Calumet County, Wisconsin	52,433	52,462	52,587	52,718
+.Chippewa County, Wisconsin	66,302	66,337	66,628	66,807
+.Clark County, Wisconsin	34,660	34,667	34,722	34,691
+.Columbia County, Wisconsin	58,480	58,516	58,404	58,193
+.Crawford County, Wisconsin	16,115	16,084	16,082	16,007
+.Dane County, Wisconsin	561,507	562,577	561,724	568,203
+.Dodge County, Wisconsin	89,398	89,353	88,657	88,282
+.Door County, Wisconsin	30,066	30,120	30,406	30,526
+.Douglas County, Wisconsin	44,291	44,343	44,026	44,144
+.Dunn County, Wisconsin	45,434	45,441	44,509	45,651
+.Eau Claire County, Wisconsin	105,702	105,874	105,988	106,837
+.Florence County, Wisconsin	4,555	4,560	4,586	4,688
+.Fond du Lac County, Wisconsin	104,152	104,150	104,166	103,836
+.Forest County, Wisconsin	9,176	9,165	9,262	9,381
+.Grant County, Wisconsin	51,950	51,984	51,285	51,276
+.Green County, Wisconsin	37,092	37,036	37,018	36,816
+.Green Lake County, Wisconsin	19,023	19,022	19,249	19,220
+.Iowa County, Wisconsin	23,709	23,709	23,777	23,865
+.Iron County, Wisconsin	6,138	6,146	6,193	6,224
+.Jackson County, Wisconsin	21,142	21,096	20,899	20,836
+.Jefferson County, Wisconsin	86,151	86,193	85,796	85,784
+.Juneau County, Wisconsin	26,721	26,780	26,756	26,866
+.Kenosha County, Wisconsin	169,156	169,184	168,465	167,817
+.Kewaunee County, Wisconsin	20,556	20,550	20,577	20,623
+.La Crosse County, Wisconsin	120,796	120,930	119,367	120,294
+.Lafayette County, Wisconsin	16,608	16,613	16,816	16,877
+.Langlade County, Wisconsin	19,491	19,462	19,505	19,559
+.Lincoln County, Wisconsin	28,421	28,429	28,453	28,376
+.Manitowoc County, Wisconsin	81,360	81,384	81,479	81,172
+.Marathon County, Wisconsin	138,007	138,047	137,746	137,958
+.Marinette County, Wisconsin	41,874	41,885	41,849	41,988
+.Marquette County, Wisconsin	15,596	15,594	15,777	15,779
+.Menominee County, Wisconsin	4,250	4,256	4,292	4,197
+.Milwaukee County, Wisconsin	939,495	938,527	924,207	918,661
+.Monroe County, Wisconsin	46,270	46,296	46,246	46,109
+.Oconto County, Wisconsin	38,971	39,080	39,393	39,633
+.Oneida County, Wisconsin	37,848	37,872	38,282	38,212
+.Outagamie County, Wisconsin	190,710	190,961	191,309	192,127
+.Ozaukee County, Wisconsin	91,499	91,613	92,551	93,009
+.Pepin County, Wisconsin	7,326	7,347	7,386	7,410
+.Pierce County, Wisconsin	42,205	42,223	41,606	42,532
+.Polk County, Wisconsin	44,979	45,032	45,521	45,709
+.Portage County, Wisconsin	70,376	70,402	69,429	70,718
+.Price County, Wisconsin	14,055	14,032	14,055	14,179
+.Racine County, Wisconsin	197,720	197,536	196,439	195,846
+.Richland County, Wisconsin	17,302	17,272	17,166	17,090
+.Rock County, Wisconsin	163,692	163,751	164,192	164,060
+.Rusk County, Wisconsin	14,192	14,179	14,116	14,186
+.St. Croix County, Wisconsin	93,539	93,874	95,055	96,017
+.Sauk County, Wisconsin	65,780	65,793	65,740	65,777
+.Sawyer County, Wisconsin	18,080	18,123	18,247	18,559
+.Shawano County, Wisconsin	40,886	40,873	40,812	40,886
+.Sheboygan County, Wisconsin	118,023	118,030	117,697	117,841
+.Taylor County, Wisconsin	19,915	19,937	19,944	19,975
+.Trempealeau County, Wisconsin	30,756	30,806	30,730	30,899
+.Vernon County, Wisconsin	30,715	30,698	30,921	31,060
+.Vilas County, Wisconsin	23,047	23,097	23,522	23,763
+.Walworth County, Wisconsin	105,226	105,308	105,200	105,380
+.Washburn County, Wisconsin	16,622	16,613	16,760	16,911
+.Washington County, Wisconsin	136,756	136,784	137,237	137,688
+.Waukesha County, Wisconsin	406,971	407,467	409,080	410,434
+.Waupaca County, Wisconsin	51,811	51,791	51,992	51,488
+.Waushara County, Wisconsin	24,526	24,549	24,797	24,999
+.Winnebago County, Wisconsin	171,734	171,800	170,554	170,718
+.Wood County, Wisconsin	74,218	74,197	74,085	73,993
+.Albany County, Wyoming	37,070	37,110	37,860	38,031
+.Big Horn County, Wyoming	11,521	11,481	11,645	11,855
+.Campbell County, Wyoming	47,027	47,139	46,533	47,058
+.Carbon County, Wyoming	14,531	14,504	14,679	14,542
+.Converse County, Wyoming	13,747	13,741	13,678	13,786
+.Crook County, Wyoming	7,184	7,186	7,319	7,448
+.Fremont County, Wyoming	39,234	39,197	39,422	39,472
+.Goshen County, Wyoming	12,503	12,514	12,557	12,562
+.Hot Springs County, Wyoming	4,618	4,618	4,574	4,588
+.Johnson County, Wyoming	8,451	8,467	8,633	8,730
+.Laramie County, Wyoming	100,506	100,718	100,794	100,723
+.Lincoln County, Wyoming	19,582	19,657	20,170	20,660
+.Natrona County, Wyoming	79,955	80,282	79,660	79,601
+.Niobrara County, Wyoming	2,469	2,452	2,414	2,380
+.Park County, Wyoming	29,625	29,664	30,142	30,518
+.Platte County, Wyoming	8,603	8,632	8,674	8,645
+.Sheridan County, Wyoming	30,925	31,005	31,667	32,096
+.Sublette County, Wyoming	8,728	8,738	8,725	8,763
+.Sweetwater County, Wyoming	42,267	42,190	41,582	41,345
+.Teton County, Wyoming	23,323	23,377	23,622	23,287
+.Uinta County, Wyoming	20,446	20,457	20,655	20,712
+.Washakie County, Wyoming	7,682	7,658	7,712	7,719
+.Weston County, Wyoming	6,840	6,818	6,766	6,860
+Note: The estimates are developed from a base that incorporates the 2020 Census, Vintage 2020 estimates, and 2020 Demographic Analysis estimates. The estimates add births to, subtract deaths from, and add net migration to the April 1, 2020 estimates base. For population estimates methodology statements, see https://www.census.gov/programs-surveys/popest/technical-documentation/methodology.html. See Geographic Terms and Definitions at https://www.census.gov/programs-surveys/popest/guidance-geographies/terms-and-definitions.html for a list of the states that are included in each region. All geographic boundaries for the 2022 population estimates series are as of January 1, 2022.   				
+Suggested Citation:				
+Annual Estimates of the Resident Population for Counties in the United States: April 1, 2020 to July 1, 2022 (CO-EST2022-POP)				
+Source: U.S. Census Bureau, Population Division				
+Release Date: March 2023				

--- a/test.py
+++ b/test.py
@@ -223,7 +223,6 @@ class TestPopulations(unittest.TestCase):
                 country="United States",
                 state="Rhode Island",
                 county="Bristol County",
-                tag="Bristol County, Rhode Island 2020",
             ),
         )
 
@@ -265,7 +264,6 @@ class TestPopulations(unittest.TestCase):
                 source="https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html",
                 country="United States",
                 state="California",
-                tag="California 2022",
             ),
         )
 
@@ -278,7 +276,6 @@ class TestPopulations(unittest.TestCase):
                 date="2022-07-01",
                 source="https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html",
                 country="United States",
-                tag="United States 2022",
             ),
         )
 

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ from collections import Counter
 
 import mgs
 import pathogens
+import populations
 from mgs import MGSData
 from pathogen_properties import *
 from tree import Tree
@@ -25,7 +26,7 @@ class TestPathogens(unittest.TestCase):
 
         self.assertEqual(
             la_2020.summarize_location(),
-            "Los Angeles, California, United States",
+            "Los Angeles County, California, United States",
         )
         self.assertEqual(
             la_2020.summarize_date(),
@@ -206,6 +207,79 @@ class TestTree(unittest.TestCase):
         )
         self.assertEqual(
             self.leaf.map(f).map(g), self.leaf.map(lambda x: g(f(x)))
+        )
+
+
+class TestPopulations(unittest.TestCase):
+    def test_county_state(self):
+        self.assertEqual(
+            populations.us_population(
+                county="Bristol County", state="Rhode Island", year=2020
+            ),
+            Population(
+                people=50_774,
+                date="2020-07-01",
+                source="https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html",
+                country="United States",
+                state="Rhode Island",
+                county="Bristol County",
+                tag="Bristol County, Rhode Island 2020",
+            ),
+        )
+
+        self.assertEqual(
+            populations.us_population(
+                county="Bristol County", state="Rhode Island", year=2020
+            ).people,
+            50_774,
+        )
+        self.assertEqual(
+            populations.us_population(
+                county="Bristol County", state="Rhode Island", year=2021
+            ).people,
+            50_800,
+        )
+        self.assertEqual(
+            populations.us_population(
+                county="Bristol County", state="Rhode Island", year=2022
+            ).people,
+            50_360,
+        )
+
+        self.assertEqual(
+            populations.us_population(
+                county="Southeastern Connecticut Planning Region",
+                state="Connecticut",
+                year=2022,
+            ).people,
+            280_403,
+        )
+
+    def test_state(self):
+        self.assertEqual(
+            populations.us_population(state="California", year=2022),
+            Population(
+                # From https://www.census.gov/quickfacts/CA
+                people=39_029_342,
+                date="2022-07-01",
+                source="https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html",
+                country="United States",
+                state="California",
+                tag="California 2022",
+            ),
+        )
+
+    def test_country(self):
+        self.assertEqual(
+            populations.us_population(year=2022),
+            Population(
+                # https://www.census.gov/quickfacts/USA
+                people=333_287_557,
+                date="2022-07-01",
+                source="https://www.census.gov/data/tables/time-series/demo/popest/2020s-counties-total.html",
+                country="United States",
+                tag="United States 2022",
+            ),
         )
 
 


### PR DESCRIPTION
We added `tag=` to keep people from accidentally pairing an absolute count with the wrong population.  In cases where we're just checking that date and location match, though, we can do this automatically.

Keep `tag=` around for cases like hsv_2 where were talking about subpopulations and need to keep those clear.