### PR TITLE
target: remove some cases in which you need to `target()`

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -171,11 +171,23 @@ class Variable:
         if self.is_target and self._location():
             return self._location()
 
+        inputs = self.all_inputs | set([self])
+
+        # Check if inputs vary only in specificity
+        counties = set(i.county for i in inputs if i.county)
+        states = set(i.state for i in inputs if i.state)
+        countries = set(i.country for i in inputs if i.country)
+
+        if len(counties) == len(states) == len(countries) == 1:
+            for i in inputs:
+                if i.county:
+                    return i._location()
+        elif len(states) == len(countries) == 1:
+            for i in inputs:
+                if i.state:
+                    return i._location()
         return "; ".join(
-            sorted(
-                set(i._location() for i in self.all_inputs if i._location())
-            )
-        )
+            sorted(set(i._location() for i in inputs if i._location())))
 
     def summarize_date(self) -> Optional[tuple[datetime.date, datetime.date]]:
         if self.is_target and self.parsed_start and self.parsed_end:

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -157,37 +157,32 @@ class Variable:
 
         return datetime.date(y, m, d)
 
-    def _location(self):
-        bits = []
-        if self.county:
-            bits.append(self.county)
-        if self.state:
-            bits.append(self.state)
-        if self.country:
-            bits.append(self.country)
-        return ", ".join(bits)
-
-    def summarize_location(self, all_locations=None):
-        if self.is_target and self._location():
-            return self._location()
+    # Returns country, state, county, or raises an error if there are
+    # conflicting locations.  If you hit an error here you probably need a
+    # target() call.
+    def target_location(self) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        if self.is_target and self.country:
+            return [self.country, self.state, self.county]
 
         inputs = self.all_inputs | set([self])
 
-        # Check if inputs vary only in specificity
-        counties = set(i.county for i in inputs if i.county)
-        states = set(i.state for i in inputs if i.state)
         countries = set(i.country for i in inputs if i.country)
+        states = set(i.state for i in inputs if i.state)
+        counties = set(i.county for i in inputs if i.county)
 
-        if len(counties) == len(states) == len(countries) == 1:
-            for i in inputs:
-                if i.county:
-                    return i._location()
-        elif len(states) == len(countries) == 1:
-            for i in inputs:
-                if i.state:
-                    return i._location()
-        return "; ".join(
-            sorted(set(i._location() for i in inputs if i._location())))
+        country = state = county = None
+        
+        country, = countries
+        if states:
+            state, = states
+        if counties:
+            county, = counties
+        
+        return country, state, county
+
+    def summarize_location(self) -> str:
+        country, state, county = self.target_location()
+        return ", ".join(x for x in [county, state, country] if x)
 
     def summarize_date(self) -> Optional[tuple[datetime.date, datetime.date]]:
         if self.is_target and self.parsed_start and self.parsed_end:

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -218,9 +218,7 @@ def estimate_prevalences():
             )
 
             prevalences.append(
-                adjusted_national_prevalence.target(
-                    country="United States", date=target_date
-                )
+                adjusted_national_prevalence.target(date=target_date)
             )
 
             # Assume that all Norovirus infections are either Group I or II,
@@ -240,7 +238,6 @@ def estimate_prevalences():
                     adjusted_national_prevalence
                     * Scalar(scalar=group_I_fraction)
                 ).target(
-                    country="United States",
                     date=target_date,
                     taxid=NOROVIRUS_GROUP_I,
                 )
@@ -250,7 +247,6 @@ def estimate_prevalences():
                     adjusted_national_prevalence
                     * Scalar(scalar=group_II_fraction)
                 ).target(
-                    country="United States",
                     date=target_date,
                     taxid=NOROVIRUS_GROUP_II,
                 )

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -120,7 +120,12 @@ def estimate_prevalences():
                             )
                         ).to_prevalence(shedding_duration)
                         * underreporting
-                    ).target(date=date.isoformat())
+                    ).target(
+                        country="United States",
+                        state=state,
+                        county=county,
+                        date=date.isoformat(),
+                    )
                 )
 
     for date, annual_infections in ohio_totals.items():

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -87,16 +87,88 @@ county_populations = {
         tag="San Francisco 2020",
         source="https://www.census.gov/quickfacts/sanfranciscocountycalifornia",
     ),
+    ("Franklin", "Ohio"): Population(
+        people=1_323_800,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Franklin",
+        tag="Franklin 2020",
+        source="https://www.census.gov/quickfacts/franklincountyohio",
+    ),
+    ("Greene", "Ohio"): Population(
+        people=167_971,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Greene",
+        tag="Greene 2020",
+        source="https://www.census.gov/quickfacts/greenecountyohio",
+    ),
+    ("Lawrence", "Ohio"): Population(
+        people=58_236,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Lawrence",
+        tag="Lawrence 2020",
+        source="https://www.census.gov/quickfacts/lawrencecountyohio",
+    ),
+    ("Licking", "Ohio"): Population(
+        people=178_509,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Licking",
+        tag="Licking 2020",
+        source="https://www.census.gov/quickfacts/lickingcountyohio",
+    ),
+    ("Lucas", "Ohio"): Population(
+        people=431_273,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Lucas",
+        tag="Lucas 2020",
+        source="https://www.census.gov/quickfacts/lucascountyohio",
+    ),
+    ("Montogmery", "Ohio"): Population(
+        people=537_316,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Montogmery",
+        tag="Montogmery 2020",
+        source="https://www.census.gov/quickfacts/montgomerycountyohio",
+    ),
+    ("Sandusky", "Ohio"): Population(
+        people=58_900,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Sandusky",
+        tag="Sandusky 2020",
+        source="https://www.census.gov/quickfacts/sanduskycountyohio",
+    ),
+    ("Summit", "Ohio"): Population(
+        people=540_436,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Summit",
+        tag="Summit 2020",
+        source="https://www.census.gov/quickfacts/summitcountyohio",
+    ),
+    ("Trumbull", "Ohio"): Population(
+        people=202_069,
+        date="2020-04-01",
+        country="United States",
+        state="Ohio",
+        county="Trumbull",
+        tag="Trumbull 2020",
+        source="https://www.census.gov/quickfacts/trumbullcountyohio",
+    ),
 }
-
-ohio_population = Population(
-    people=11_799_374,
-    date="2020-04-01",
-    country="United States",
-    state="Ohio",
-    tag="Ohio 2020",
-    source="https://www.census.gov/quickfacts/OH",
-)
 
 
 def estimate_prevalences():
@@ -115,7 +187,7 @@ def estimate_prevalences():
             county = row[5]
             state = row[6]
 
-            if state != "Ohio" and (county, state) not in county_populations:
+            if (county, state) not in county_populations:
                 continue
 
             # In the tsv file, cumulative case counts start at column 11 with
@@ -143,30 +215,28 @@ def estimate_prevalences():
                 # https://www.jefftk.com/p/careful-with-trailing-averages
                 date = str(day - datetime.timedelta(days=3))
                 annual_infections = sum(latest) * 52
-                if state == "Ohio":
-                    ohio_totals[date] += annual_infections
-                else:
-                    cases = IncidenceAbsolute(
-                        annual_infections=annual_infections,
+
+                cases = IncidenceAbsolute(
+                    annual_infections=annual_infections,
+                    country="United States",
+                    state=state,
+                    county=county,
+                    date=date,
+                    tag="%s 2020" % county,
+                )
+                estimates.append(
+                    (
+                        cases.to_rate(
+                            county_populations[county, state]
+                        ).to_prevalence(shedding_duration)
+                        * underreporting
+                    ).target(
                         country="United States",
                         state=state,
                         county=county,
                         date=date,
-                        tag="%s 2020" % county,
                     )
-                    estimates.append(
-                        (
-                            cases.to_rate(
-                                county_populations[county, state]
-                            ).to_prevalence(shedding_duration)
-                            * underreporting
-                        ).target(
-                            country="United States",
-                            state=state,
-                            county=county,
-                            date=date,
-                        )
-                    )
+                )
 
     for date, annual_infections in ohio_totals.items():
         cases = IncidenceAbsolute(

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -41,14 +41,14 @@ target_counties = set(
         "Alameda County, California",
         "Marin County, California",
         "San Francisco County, California",
-        "Franklin County, Ohio"
-        "Greene County, Ohio"
-        "Lawrence County, Ohio"
-        "Licking County, Ohio"
-        "Lucas County, Ohio"
-        "Montogmery County, Ohio"
-        "Sandusky County, Ohio"
-        "Summit County, Ohio"
+        "Franklin County, Ohio",
+        "Greene County, Ohio",
+        "Lawrence County, Ohio",
+        "Licking County, Ohio",
+        "Lucas County, Ohio",
+        "Montogmery County, Ohio",
+        "Sandusky County, Ohio",
+        "Summit County, Ohio",
         "Trumbull County, Ohio",
     ]
 )

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -127,12 +127,7 @@ def estimate_prevalences():
                             )
                         ).to_prevalence(shedding_duration)
                         * underreporting
-                    ).target(
-                        country="United States",
-                        state=state,
-                        county=county,
-                        date=date.isoformat(),
-                    )
+                    ).target(date=date.isoformat())
                 )
 
     return estimates

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -57,8 +57,6 @@ target_counties = set(
 def estimate_prevalences():
     estimates = []
 
-    ohio_totals = Counter()  # day -> total new cases, 7d moving average
-
     # From the COVID-19 Data Repository by the Center for Systems Science and
     # Engineering (CSSE) at Johns Hopkins University
     #
@@ -103,6 +101,15 @@ def estimate_prevalences():
                 if date.year > 2022:
                     continue
 
+                # Right now we use the same underreporting figure for both
+                # Spring/Fall 2020 and Winter 2021-2022.
+                #
+                # TODO: we can probably get a better undereporting figure for
+                # the omicron surge and this is likely too small.  The CDC 4x
+                # figure is not intended to cover this time period, this was
+                # after rapid tests were starting to be available, and omicron
+                # was relatively mild.
+
                 annual_infections = sum(latest) * 52
 
                 cases = IncidenceAbsolute(
@@ -127,29 +134,5 @@ def estimate_prevalences():
                         date=date.isoformat(),
                     )
                 )
-
-    for date, annual_infections in ohio_totals.items():
-        cases = IncidenceAbsolute(
-            annual_infections=annual_infections,
-            country="United States",
-            state="Ohio",
-            date=date.isoformat(),
-        )
-        # TODO: we can probably get a better undereporting figure for the
-        # omicron surge and this is likely too small.  The CDC 4x figure is not
-        # intended to cover this time period, this was after rapid tests were
-        # starting to be available, and omicron was relatively mild.
-        estimates.append(
-            (
-                cases.to_rate(
-                    us_population(state="Ohio", year=date.year)
-                ).to_prevalence(shedding_duration)
-                * underreporting
-            ).target(
-                country="United States",
-                state="Ohio",
-                date=date.isoformat(),
-            )
-        )
 
     return estimates


### PR DESCRIPTION
If you're calling target to specify the location for an estimate, and the location you want is just the most specific location of any of your inputs, you don't need to call `target()` anymore.
