### PR TITLE
Add date_source

### DIFF
--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -130,7 +130,7 @@ def estimate_prevalences():
                             )
                         ).to_prevalence(shedding_duration)
                         * underreporting
-                    ).target(date=date.isoformat())
+                    )
                 )
 
     return estimates

--- a/summarize.py
+++ b/summarize.py
@@ -19,31 +19,31 @@ def start(pathogen_names):
 
         for n, estimate in enumerate(pathogen.estimate_prevalences()):
             date = "no date"
-            date_summary = estimate.summarize_date()
-            if date_summary:
-                start_date, end_date = date_summary
-                _, end_date_month_last_day = calendar.monthrange(
-                    end_date.year, end_date.month
-                )
-                if start_date == end_date:
-                    date = start_date
-                elif start_date.year != end_date.year:
-                    date = f"{start_date.year} to {end_date.year}"
-                elif (
-                    start_date.month == 1
-                    and start_date.day == 1
-                    and end_date.month == 12
-                    and end_date.day == 31
-                ):
-                    date = start_date.year
-                elif (
-                    start_date.month == end_date.month
-                    and start_date.day == 1
-                    and end_date.day == end_date_month_last_day
-                ):
-                    date = f"{start_date.year}-{start_date.month:02d}"
-                else:
-                    date = f"{start_date} to {end_date}"
+
+            start_date = estimate.parsed_start
+            end_date = estimate.parsed_end
+            _, end_date_month_last_day = calendar.monthrange(
+                end_date.year, end_date.month
+            )
+            if start_date == end_date:
+                date = start_date
+            elif start_date.year != end_date.year:
+                date = f"{start_date.year} to {end_date.year}"
+            elif (
+                start_date.month == 1
+                and start_date.day == 1
+                and end_date.month == 12
+                and end_date.day == 31
+            ):
+                date = start_date.year
+            elif (
+                start_date.month == end_date.month
+                and start_date.day == 1
+                and end_date.day == end_date_month_last_day
+            ):
+                date = f"{start_date.year}-{start_date.month:02d}"
+            else:
+                date = f"{start_date} to {end_date}"
 
             location = estimate.summarize_location()
 

--- a/test.py
+++ b/test.py
@@ -19,15 +19,17 @@ class TestPathogens(unittest.TestCase):
     def test_summarize_location(self):
         us_2019, la_2020 = pathogens.pathogens["hiv"].estimate_prevalences()
         self.assertEqual(us_2019.summarize_location(), "United States")
-        self.assertEqual(us_2019.parsed_start, datetime.date(2019, 1, 1))
-        self.assertEqual(us_2019.parsed_end, datetime.date(2019, 12, 31))
-
         self.assertEqual(
             la_2020.summarize_location(),
             "Los Angeles County, California, United States",
         )
-        self.assertEqual(la_2020.parsed_start, datetime.date(2020, 1, 1))
 
+    def test_dstes(self):
+        us_2019, la_2020 = pathogens.pathogens["hiv"].estimate_prevalences()
+        self.assertEqual(us_2019.parsed_start, datetime.date(2019, 1, 1))
+        self.assertEqual(us_2019.parsed_end, datetime.date(2019, 12, 31))
+
+        self.assertEqual(la_2020.parsed_start, datetime.date(2020, 1, 1))
         self.assertEqual(la_2020.parsed_end, datetime.date(2020, 12, 31))
 
     def test_properties_exist(self):
@@ -44,8 +46,8 @@ class TestPathogens(unittest.TestCase):
         for pathogen_name, pathogen in pathogens.pathogens.items():
             with self.subTest(pathogen=pathogen_name):
                 for estimate in pathogen.estimate_prevalences():
-                    self.assertTrue(estimate.parsed_start)
-                    self.assertTrue(estimate.parsed_end)
+                    self.assertIsNotNone(estimate.parsed_start)
+                    self.assertIsNotNone(estimate.parsed_end)
 
 
 class TestVaribles(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -19,19 +19,16 @@ class TestPathogens(unittest.TestCase):
     def test_summarize_location(self):
         us_2019, la_2020 = pathogens.pathogens["hiv"].estimate_prevalences()
         self.assertEqual(us_2019.summarize_location(), "United States")
-        self.assertEqual(
-            us_2019.summarize_date(),
-            (datetime.date(2019, 1, 1), datetime.date(2019, 12, 31)),
-        )
+        self.assertEqual(us_2019.parsed_start, datetime.date(2019, 1, 1))
+        self.assertEqual(us_2019.parsed_end, datetime.date(2019, 12, 31))
 
         self.assertEqual(
             la_2020.summarize_location(),
             "Los Angeles County, California, United States",
         )
-        self.assertEqual(
-            la_2020.summarize_date(),
-            (datetime.date(2020, 1, 1), datetime.date(2020, 12, 31)),
-        )
+        self.assertEqual(la_2020.parsed_start, datetime.date(2020, 1, 1))
+
+        self.assertEqual(la_2020.parsed_end, datetime.date(2020, 12, 31))
 
     def test_properties_exist(self):
         for pathogen_name, pathogen in pathogens.pathogens.items():
@@ -42,6 +39,13 @@ class TestPathogens(unittest.TestCase):
 
                 for estimate in pathogen.estimate_prevalences():
                     self.assertIsInstance(estimate, Prevalence)
+
+    def test_dates_set(self):
+        for pathogen_name, pathogen in pathogens.pathogens.items():
+            with self.subTest(pathogen=pathogen_name):
+                for estimate in pathogen.estimate_prevalences():
+                    self.assertTrue(estimate.parsed_start)
+                    self.assertTrue(estimate.parsed_end)
 
 
 class TestVaribles(unittest.TestCase):
@@ -69,6 +73,11 @@ class TestVaribles(unittest.TestCase):
         v = Variable(start_date="2020-01-07", end_date="2020-02-06")
         self.assertEqual(v.parsed_start, datetime.date(2020, 1, 7))
         self.assertEqual(v.parsed_end, datetime.date(2020, 2, 6))
+
+        v1 = Variable(date="2019")
+        v2 = Variable(date="2020", date_source=v1)
+        self.assertEqual(v2.parsed_start, datetime.date(2019, 1, 1))
+        self.assertEqual(v2.parsed_end, datetime.date(2019, 12, 31))
 
         with self.assertRaises(Exception):
             Variable(start_date="2020-01-07")


### PR DESCRIPTION
In working on fixing #87 I'm now doing something where incidence estimates targeting several different dates are being combined into a prevalence estimate targeting a single date. This exposed a bunch of issues with the way I'd initially set things up with `target()`. Now:

* When creating a `Variable` from other `Variable`s you can provide a `date_source`, as a way of saying which particular input variable controls the date the estimate is for.

* When you want to know when an estimate is for you just look at `parsed_start` and `parsed_end`, you don't have to investigate inputs.

* If you have an estimate that is targeting the wrong date, you can fix it with `dataclasses.replace(estimate, date_source=variable)`

`dataclasses.replace` can actually handle all of the cases where I was previously using `target()`, and is a much more robust way of handling this.

One downside is that `dataclasses.replace` skips `init=False` properties, so I needed to tweak a few properties to no longer be `init=False`.