### PR TITLE
incidence to prevalence: consider incidence over time

### DIFF
--- a/fit_covid.py
+++ b/fit_covid.py
@@ -25,8 +25,7 @@ if __name__ == "__main__":
 
     prevalence_by_loc_date = {}
     for estimate in pathogens[pathogen].estimate_prevalences():
-        assert estimate.parsed_start == estimate.parsed_end
-        key = (estimate.county, estimate.parsed_start)
+        key = (estimate.county, estimate.get_date())
         assert key not in prevalence_by_loc_date
         prevalence_by_loc_date[key] = estimate.infections_per_100k
 

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -330,20 +330,18 @@ class SheddingDuration(Variable):
 
         assert len(candiate_incidences) == max_days
 
-        incidence_day = target_day
         infections_per_100k = 0.0
-        n = 0
-        while incidence_day > oldest_day:
-            n += 1
+        for days_prior in range(max_days):
+            incidence_day = target_day - datetime.timedelta(days=days_prior)
+
             weight = 1.0
-            if n > math.floor(self.days):
-                weight = math.floor(self.days) - n
+            if days_prior == max_days - 1:
+                weight = self.days - math.floor(self.days)
             infections_per_100k += (
                 weight
                 * candiate_incidences[incidence_day].annual_infections_per_100k
                 / 365
             )
-            incidence_day -= datetime.timedelta(days=1)
 
         return Prevalence(
             infections_per_100k=infections_per_100k,

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -192,8 +192,14 @@ class Variable:
 
         try:
             return min(
-                i.parsed_start for i in self.all_inputs if i.parsed_start
-            ), max(i.parsed_end for i in self.all_inputs if i.parsed_end)
+                i.parsed_start
+                for i in self.all_inputs | set([self])
+                if i.parsed_start
+            ), max(
+                i.parsed_end
+                for i in self.all_inputs | set([self])
+                if i.parsed_end
+            )
         except ValueError:
             return None
 

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -61,6 +61,8 @@ def estimate_prevalences():
     # Engineering (CSSE) at Johns Hopkins University
     #
     # Downloaded 2023-05-02 from https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv
+    incidences = []
+
     with open(
         prevalence_data_filename("time_series_covid19_confirmed_US.csv")
     ) as inf:
@@ -122,15 +124,13 @@ def estimate_prevalences():
                     county=county,
                     date=date.isoformat(),
                 )
-                estimates.append(
-                    (
-                        cases.to_rate(
-                            us_population(
-                                county=county, state=state, year=date.year
-                            )
-                        ).to_prevalence(shedding_duration)
-                        * underreporting
-                    ).target(date=date.isoformat())
+                incidences.append(
+                    cases.to_rate(
+                        us_population(
+                            county=county, state=state, year=date.year
+                        )
+                    ).target(
+                    * underreporting
                 )
 
-    return estimates
+    return shedding_duration.prevalences_from_incidences(incidences)

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -61,12 +61,12 @@ def estimate_prevalences():
     # Engineering (CSSE) at Johns Hopkins University
     #
     # Downloaded 2023-05-02 from https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv
-    incidences = []
-
     with open(
         prevalence_data_filename("time_series_covid19_confirmed_US.csv")
     ) as inf:
         for row in csv.reader(inf):
+            incidences = []
+
             truncated_county = row[5]
             state = row[6]
 
@@ -130,7 +130,10 @@ def estimate_prevalences():
                         us_population(
                             county=county, state=state, year=date.year
                         )
-                    ) * underreporting
+                    )
+                    * underreporting
                 )
-
-    return shedding_duration.prevalences_from_incidences(incidences)
+            estimates.extend(
+                shedding_duration.prevalences_from_incidences(incidences)
+            )
+    return estimates

--- a/summarize.py
+++ b/summarize.py
@@ -20,8 +20,7 @@ def start(pathogen_names):
         for n, estimate in enumerate(pathogen.estimate_prevalences()):
             date = "no date"
 
-            start_date = estimate.parsed_start
-            end_date = estimate.parsed_end
+            start_date, end_date = estimate.get_dates()
             _, end_date_month_last_day = calendar.monthrange(
                 end_date.year, end_date.month
             )

--- a/test.py
+++ b/test.py
@@ -46,40 +46,53 @@ class TestPathogens(unittest.TestCase):
         for pathogen_name, pathogen in pathogens.pathogens.items():
             with self.subTest(pathogen=pathogen_name):
                 for estimate in pathogen.estimate_prevalences():
-                    self.assertIsNotNone(estimate.parsed_start)
-                    self.assertIsNotNone(estimate.parsed_end)
+                    estimate.get_dates()
 
 
 class TestVaribles(unittest.TestCase):
     def test_date_parsing(self):
         v = Variable(date="2019")
-        self.assertEqual(v.parsed_start, datetime.date(2019, 1, 1))
-        self.assertEqual(v.parsed_end, datetime.date(2019, 12, 31))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2019, 1, 1), datetime.date(2019, 12, 31)),
+        )
 
         v = Variable(date="2019-02")
-        self.assertEqual(v.parsed_start, datetime.date(2019, 2, 1))
-        self.assertEqual(v.parsed_end, datetime.date(2019, 2, 28))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2019, 2, 1), datetime.date(2019, 2, 28)),
+        )
 
         v = Variable(date="2020-02")
-        self.assertEqual(v.parsed_start, datetime.date(2020, 2, 1))
-        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 29))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2020, 2, 1), datetime.date(2020, 2, 29)),
+        )
 
         v = Variable(date="2020-02-01")
-        self.assertEqual(v.parsed_start, datetime.date(2020, 2, 1))
-        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 1))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2020, 2, 1), datetime.date(2020, 2, 1)),
+        )
 
         v = Variable(start_date="2020-01", end_date="2020-02")
-        self.assertEqual(v.parsed_start, datetime.date(2020, 1, 1))
-        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 29))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2020, 1, 1), datetime.date(2020, 2, 29)),
+        )
 
         v = Variable(start_date="2020-01-07", end_date="2020-02-06")
-        self.assertEqual(v.parsed_start, datetime.date(2020, 1, 7))
-        self.assertEqual(v.parsed_end, datetime.date(2020, 2, 6))
+        self.assertEqual(
+            v.get_dates(),
+            (datetime.date(2020, 1, 7), datetime.date(2020, 2, 6)),
+        )
 
         v1 = Variable(date="2019")
         v2 = Variable(date="2020", date_source=v1)
-        self.assertEqual(v2.parsed_start, datetime.date(2019, 1, 1))
-        self.assertEqual(v2.parsed_end, datetime.date(2019, 12, 31))
+        self.assertEqual(
+            v2.get_dates(),
+            (datetime.date(2019, 1, 1), datetime.date(2019, 12, 31)),
+        )
 
         with self.assertRaises(Exception):
             Variable(start_date="2020-01-07")
@@ -104,6 +117,16 @@ class TestVaribles(unittest.TestCase):
 
         with self.assertRaises(Exception):
             Variable(date="2020/01/01")
+
+        v = Variable(date="2020")
+        with self.assertRaises(AssertionError):
+            v.get_date()  # asserts start==end
+
+        v = Variable()
+        self.assertIsNone(v.parsed_start)
+        self.assertIsNone(v.parsed_end)
+        with self.assertRaises(AssertionError):
+            v.get_dates()  # asserts dates are set
 
 
 class TestMGS(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -314,5 +314,21 @@ class TestPopulations(unittest.TestCase):
         )
 
 
+class TestPrevalenceFromIncidence(unittest.TestCase):
+    def test_prevalence_from_incidences(self):
+        sd = SheddingDuration(days=5.6)
+        incidences = [
+            IncidenceRate(annual_infections_per_100k=i, date="2000-01-0%s" % i)
+            for i in range(1, 10)
+        ]
+        target_date = datetime.date(2000, 1, 9)
+        self.assertAlmostEqual(
+            (9 + 8 + 7 + 6 + 5 + 4 * 0.6) / 365,
+            sd.prevalence_from_incidences(
+                target_date, incidences
+            ).infections_per_100k,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The number of currently infected people today is not today's incidence times the mean shedding duration.  It's much closer to the sum of incidences over the last shedding duration days.  Do that instead.

Here's how this changes our predictions for LA County.  Relatively subtle, but you can see it pushes peaks a bit into the future, and spreads them a bit horizontally, as you'd expect:

![Screenshot 2023-05-12 at 2 44 53 PM](https://github.com/naobservatory/p2ra/assets/262566/9ca33ce0-825f-47cd-b0a7-ab0a498aa6d1)

Fixes #87 
