### PR TITLE
Stop converting incidences to prevalences

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -329,63 +329,6 @@ class PrevalenceAbsolute(Taggable):
 
 
 @dataclass(kw_only=True, eq=True, frozen=True)
-class SheddingDuration(Variable):
-    days: float
-
-    # The model here is that shedding is binary: on the first day of infection
-    # you begin to shed at 100%, and then after `days` you shed 0%.  This is a
-    # big simplification!
-    #
-    # Incidences should contain daily estimates for target_day and at least the
-    # prior `days` days.
-    def prevalence_from_incidences(
-        self, target_day: datetime.date, incidences: list["IncidenceRate"]
-    ) -> Prevalence:
-        max_days = math.ceil(self.days)
-        oldest_day = target_day - datetime.timedelta(days=max_days)
-        candiate_incidences = {}
-        for incidence in incidences:
-            incidence_day = incidence.get_date()
-            if oldest_day < incidence_day <= target_day:
-                candiate_incidences[incidence_day] = incidence
-
-        assert len(candiate_incidences) == max_days
-
-        infections_per_100k = 0.0
-        for days_prior in range(max_days):
-            incidence_day = target_day - datetime.timedelta(days=days_prior)
-
-            weight = 1.0
-            if days_prior == max_days - 1:
-                weight = self.days - math.floor(self.days)
-            infections_per_100k += (
-                weight
-                * candiate_incidences[incidence_day].annual_infections_per_100k
-                / 365
-            )
-
-        return Prevalence(
-            infections_per_100k=infections_per_100k,
-            inputs=[self, *candiate_incidences.values()],
-            active=Active.ACTIVE,
-            date_source=candiate_incidences[target_day],
-            location_source=candiate_incidences[target_day],
-        )
-
-    def prevalences_from_incidences(
-        self, incidences: list["IncidenceRate"]
-    ) -> list[Prevalence]:
-        dates = set(incidence.get_date() for incidence in incidences)
-        first_date = min(dates) + datetime.timedelta(days=math.ceil(self.days))
-
-        return [
-            self.prevalence_from_incidences(target_date, incidences)
-            for target_date in sorted(dates)
-            if target_date >= first_date
-        ]
-
-
-@dataclass(kw_only=True, eq=True, frozen=True)
 class Number(Variable):
     """Generic number.  Use this for weird one-off things
 
@@ -408,26 +351,6 @@ class IncidenceRate(Variable):
     """What fraction of people get this pathogen annually"""
 
     annual_infections_per_100k: float
-
-    # Any estimate derived from an incidence using a shedding duration must be
-    # an active estimate, since multiplying by SheddingDuration calculates the
-    # amount of time the virus is actively shedding for, which is not
-    # incorporated into a latent estimate.
-    #
-    # Only use this method in situations where incidence is changing slowly
-    # relative to shedding_duration; of doesn't take into account that current
-    # prevalence includes past incidence over the shedding period.  If this
-    # does apply, use SheddingDuration.prevalences_from_incidences.
-    def to_prevalence(self, shedding_duration: SheddingDuration) -> Prevalence:
-        return Prevalence(
-            infections_per_100k=self.annual_infections_per_100k
-            * shedding_duration.days
-            / 365,
-            inputs=[self, shedding_duration],
-            active=Active.ACTIVE,
-            date_source=self,
-            location_source=self,
-        )
 
     def __mul__(self, scalar: Scalar) -> "IncidenceRate":
         return IncidenceRate(

--- a/pathogens/dengue.py
+++ b/pathogens/dengue.py
@@ -22,16 +22,14 @@ california_reported_cases = IncidenceAbsolute(
     source="https://www.cdph.ca.gov/Programs/CID/DCDC/CDPH%20Document%20Library/TravelAssociatedCasesofDengueVirusinCA.pdf",
 )
 
-# disease duration in days
-disease_duration = SheddingDuration(
-    days=7,
-    source="https://www.cdc.gov/dengue/symptoms/index.html",
-)
 
-
-def estimate_prevalences():
+def estimate_incidences() -> list[IncidenceRate]:
     return [
         california_reported_cases.to_rate(
             us_population(state="California", year=2020)
-        ).to_prevalence(disease_duration)
+        )
     ]
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    return []

--- a/pathogens/hav.py
+++ b/pathogens/hav.py
@@ -35,13 +35,6 @@ us_population_2018 = Population(
     source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
 )
 
-hva_shedding_duration = SheddingDuration(
-    days=14,
-    confidence_interval=(7, 21),
-    country="United States",
-    source="https://www.cdc.gov/vaccines/pubs/pinkbook/hepa.html#:~:text=Viral%20shedding%20persists%20for%201%20to%203%20weeks.",
-)
-
 incidence_underreporting_scalar = Scalar(
     scalar=1 / 0.59,
     confidence_interval=(
@@ -91,17 +84,15 @@ king_county_confirmed_cases_rate_2018 = IncidenceRate(
 )
 
 
-def estimate_prevalences():
+def estimate_incidences() -> list[IncidenceRate]:
     return [
-        us_incidence_absolute_2018.to_rate(us_population_2018).to_prevalence(
-            hva_shedding_duration
-        ),
-        king_county_confirmed_cases_rate_2017.to_prevalence(
-            hva_shedding_duration
-        )
+        us_incidence_absolute_2018.to_rate(us_population_2018),
+        king_county_confirmed_cases_rate_2017
         * incidence_underreporting_scalar,
-        king_county_confirmed_cases_rate_2018.to_prevalence(
-            hva_shedding_duration
-        )
+        king_county_confirmed_cases_rate_2018
         * incidence_underreporting_scalar,
     ]
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    return []

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -24,14 +24,6 @@ pathogen_chars = PathogenChars(
     taxid=TaxID(10407),
 )
 
-dna_present_in_serum = SheddingDuration(
-    days=2.5 * 30.5,  # 2.5 months
-    date="2014",
-    source="https://doi.org/10.1016/S0140-6736(14)60220-8",  # Figure 2.
-    # No citation, but HBV-DNA is listed as a detectable serum marker for 2.5
-    # months
-)
-
 cdc_estimated_acute_2019 = IncidenceAbsolute(
     annual_infections=20_700,
     # During 2019, a total of 3,192 acute hepatitis B cases were reported to
@@ -74,10 +66,9 @@ us_population_2019 = Population(
 )
 
 
-def estimate_prevalences():
-    return [
-        cdc_estimated_acute_2019.to_rate(us_population_2019).to_prevalence(
-            dna_present_in_serum
-        ),
-        estimated_chronic_us_2020.to_rate(us_population(year=2020)),
-    ]
+def estimate_prevalences() -> list[Prevalence]:
+    return [estimated_chronic_us_2020.to_rate(us_population(year=2020))]
+
+
+def estimate_incidences() -> list[IncidenceRate]:
+    return [cdc_estimated_acute_2019.to_rate(us_population_2019)]

--- a/pathogens/hiv.py
+++ b/pathogens/hiv.py
@@ -56,7 +56,7 @@ la_infected_2020 = PrevalenceAbsolute(
 )
 
 
-def estimate_prevalences():
+def estimate_prevalences() -> list[Prevalence]:
     return [
         us_infected_2019.to_rate(us_population_2019)
         * us_unsuppressed_fraction_2019,
@@ -67,3 +67,7 @@ def estimate_prevalences():
         )
         * la_unsuppressed_fraction_2020,
     ]
+
+
+def estimate_incidences() -> list[IncidenceRate]:
+    return []

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -44,9 +44,13 @@ tear_and_saliva_prevalence = Prevalence(
 )
 
 
-def estimate_prevalences():
+def estimate_prevalences() -> list[Prevalence]:
     return [
         cdc_2015_2016_nhanes_seroprevalence,
         cdc_2015_2016_nhanes_estimate,
         tear_and_saliva_prevalence,
     ]
+
+
+def estimate_incidences() -> list[IncidenceRate]:
+    return []

--- a/pathogens/hsv_2.py
+++ b/pathogens/hsv_2.py
@@ -102,9 +102,13 @@ us_population_2018_18_to_49yo = Population(
 )
 
 
-def estimate_prevalences():
+def estimate_prevalences() -> list[Prevalence]:
     return [
         cdc_2015_2016_nhanes_seroprevalence,
         cdc_2015_2016_nhanes_estimate,
         cdc_2018_nhanes_estimate.to_rate(us_population_2018_18_to_49yo),
     ]
+
+
+def estimate_incidences() -> list[IncidenceRate]:
+    return []

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -64,13 +64,6 @@ us_population_2006 = Population(
     source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3375761/#:~:text=population%20in%202006%20(-,299%20million%20persons,-).%20Estimates%20were%20derived",
 )
 
-shedding_duration = SheddingDuration(
-    days=2,
-    confidence_interval=(1, 3),
-    # "Norovirus infection symptoms usually last 1 to 3 days"
-    source="https://www.mayoclinic.org/diseases-conditions/norovirus/symptoms-causes/syc-20355296#:~:text=Norovirus%20infection%20symptoms%20usually%20last%201%20to%203%20days",
-)
-
 monthwise_count = dict[tuple[int, int], float]  # [year, month] -> float
 
 
@@ -186,18 +179,16 @@ COVID_START = 2020
 DATA_END = 2022
 
 
-def estimate_prevalences():
-    prevalences = []
+def estimate_incidences() -> list[IncidenceRate]:
+    incidences = []
 
     us_outbreaks, us_outbreaks_I, us_outbreaks_II = load_nors_outbreaks()
     pre_covid_us_average_daily_outbreaks = determine_average_daily_outbreaks(
         us_outbreaks
     )
 
-    pre_covid_national_prevalence = (
-        us_national_foodborne_cases_2006.to_rate(
-            us_population_2006
-        ).to_prevalence(shedding_duration)
+    pre_covid_national_incidence = (
+        us_national_foodborne_cases_2006.to_rate(us_population_2006)
         * us_total_relative_to_foodborne_2006
     )
 
@@ -212,12 +203,12 @@ def estimate_prevalences():
                 date=f"{year}-{month:02d}",
                 source="https://wwwn.cdc.gov/norsdashboard/",
             )
-            adjusted_national_prevalence = dataclasses.replace(
-                pre_covid_national_prevalence * adjustment,
+            adjusted_national_incidence = dataclasses.replace(
+                pre_covid_national_incidence * adjustment,
                 date_source=adjustment,
             )
 
-            prevalences.append(adjusted_national_prevalence)
+            incidences.append(adjusted_national_incidence)
 
             # Assume that all Norovirus infections are either Group I or II,
             # which is very close (see assertion above).  Also assume the
@@ -231,19 +222,23 @@ def estimate_prevalences():
             else:
                 group_I_fraction = group_II_fraction = 0
 
-            prevalences.append(
+            incidences.append(
                 dataclasses.replace(
-                    adjusted_national_prevalence
+                    adjusted_national_incidence
                     * Scalar(scalar=group_I_fraction),
                     taxid=NOROVIRUS_GROUP_I,
                 )
             )
-            prevalences.append(
+            incidences.append(
                 dataclasses.replace(
-                    adjusted_national_prevalence
+                    adjusted_national_incidence
                     * Scalar(scalar=group_II_fraction),
                     taxid=NOROVIRUS_GROUP_II,
                 )
             )
 
-    return prevalences
+    return incidences
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    return []

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -15,14 +15,6 @@ pathogen_chars = PathogenChars(
     taxid=TaxID(2697049),
 )
 
-shedding_duration = SheddingDuration(
-    days=18,
-    # "In a review of 28 studies, the pooled median duration of viral RNA
-    # detection in respiratory specimens was 18 days following the onset of
-    # symptoms."
-    source="https://www.uptodate.com/contents/covid-19-epidemiology-virology-and-prevention/print",
-)
-
 underreporting = Scalar(
     scalar=4.0,
     confidence_interval=(3.4, 4.7),
@@ -54,7 +46,7 @@ target_counties = set(
 )
 
 
-def estimate_prevalences():
+def estimate_incidences() -> list[IncidenceRate]:
     estimates = []
 
     # From the COVID-19 Data Repository by the Center for Systems Science and
@@ -65,8 +57,6 @@ def estimate_prevalences():
         prevalence_data_filename("time_series_covid19_confirmed_US.csv")
     ) as inf:
         for row in csv.reader(inf):
-            incidences = []
-
             truncated_county = row[5]
             state = row[6]
 
@@ -125,7 +115,7 @@ def estimate_prevalences():
                     date=date.isoformat(),
                 )
 
-                incidences.append(
+                estimates.append(
                     cases.to_rate(
                         us_population(
                             county=county, state=state, year=date.year
@@ -133,7 +123,9 @@ def estimate_prevalences():
                     )
                     * underreporting
                 )
-            estimates.extend(
-                shedding_duration.prevalences_from_incidences(incidences)
-            )
+
     return estimates
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    return []

--- a/pathogens/west_nile_virus.py
+++ b/pathogens/west_nile_virus.py
@@ -27,15 +27,6 @@ LA_county_cases_in_2020 = IncidenceAbsolute(
     source="https://westnile.ca.gov/pdfs/VBDSAnnualReport20.pdf#?page=23",
 )
 
-west_nile_duration = SheddingDuration(
-    # Symptoms last for 3-6 days usually, but sometimes for up to a month. I'm
-    # going to use 7 days as an estimate, since I cannot find a better source
-    # on this
-    days=10,
-    confidence_interval=(2, 18),
-    source="https://myhealth.alberta.ca/Health/aftercareinformation/pages/conditions.aspx?hwid=abo5809#:~:text=In%20mild%20cases%20of%20West%20Nile%2C%20symptoms%20usually%20last%20for%203%20to%206%20days%2C%20and%20you%20can%20recover%20at%20home.%20If%20you%20get%20a%20more%20severe%20case%20of%20West%20Nile%2C%20symptoms%20can%20last%20for%20weeks%20or%20months%2C%20and%20you%20may%20need%20to%20stay%20in%20the%20hospital%20so%20you%20can%20get%20medicine%20to%20help%20you%20recover.",
-)
-
 # 3/4 of people with WNV are asymptomatic, and therefore probably did not get
 # tested
 asymptomatic_multiplier = Scalar(
@@ -44,12 +35,16 @@ asymptomatic_multiplier = Scalar(
 )
 
 
-def estimate_prevalences():
+def estimate_incidences() -> list[IncidenceRate]:
     return [
         LA_county_cases_in_2020.to_rate(
             us_population(
                 county="Los Angeles County", state="California", year=2020
             )
-        ).to_prevalence(west_nile_duration)
+        )
         * asymptomatic_multiplier
     ]
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    return []

--- a/summarize.py
+++ b/summarize.py
@@ -3,8 +3,35 @@ import calendar
 import sys
 
 import pathogens
+from pathogen_properties import Variable
 
 MAX_ESTIMATES_FOR_PATHOGEN = 5
+
+
+def pretty_date(estimate: Variable) -> str:
+    start_date, end_date = estimate.get_dates()
+    _, end_date_month_last_day = calendar.monthrange(
+        end_date.year, end_date.month
+    )
+    if start_date == end_date:
+        return str(start_date)
+    elif start_date.year != end_date.year:
+        return f"{start_date.year} to {end_date.year}"
+    elif (
+        start_date.month == 1
+        and start_date.day == 1
+        and end_date.month == 12
+        and end_date.day == 31
+    ):
+        return str(start_date.year)
+    elif (
+        start_date.month == end_date.month
+        and start_date.day == 1
+        and end_date.day == end_date_month_last_day
+    ):
+        return f"{start_date.year}-{start_date.month:02d}"
+    else:
+        return f"{start_date} to {end_date}"
 
 
 def start(pathogen_names):
@@ -17,46 +44,28 @@ def start(pathogen_names):
 
         to_print = []  # key, line
 
-        for n, estimate in enumerate(pathogen.estimate_prevalences()):
-            date = "no date"
-
-            start_date, end_date = estimate.get_dates()
-            _, end_date_month_last_day = calendar.monthrange(
-                end_date.year, end_date.month
-            )
-            if start_date == end_date:
-                date = start_date
-            elif start_date.year != end_date.year:
-                date = f"{start_date.year} to {end_date.year}"
-            elif (
-                start_date.month == 1
-                and start_date.day == 1
-                and end_date.month == 12
-                and end_date.day == 31
-            ):
-                date = start_date.year
-            elif (
-                start_date.month == end_date.month
-                and start_date.day == 1
-                and end_date.day == end_date_month_last_day
-            ):
-                date = f"{start_date.year}-{start_date.month:02d}"
-            else:
-                date = f"{start_date} to {end_date}"
-
-            location = estimate.summarize_location()
-
-            prevalence = "%.2f per 100k" % estimate.infections_per_100k
+        def save(estimate: Variable, details: str):
             taxid = ""
             if estimate.taxid:
                 taxid = "; %s" % estimate.taxid
+            date = pretty_date(estimate)
+            location = estimate.summarize_location()
             line = "%s (%s; %s%s)" % (
-                prevalence.rjust(18),
+                details.rjust(18),
                 location,
                 date,
                 taxid,
             )
-            to_print.append(((location, str(date)), line))
+            to_print.append(((location, date), line))
+
+        for estimate in pathogen.estimate_prevalences():
+            save(estimate, "%.2f per 100k" % estimate.infections_per_100k)
+
+        for estimate in pathogen.estimate_incidences():
+            save(
+                estimate,
+                "%.2f per 100k/y" % estimate.annual_infections_per_100k,
+            )
 
         to_print.sort()
         for _, line in to_print[:maximum]:

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from collections import Counter
 import mgs
 import pathogens
 import populations
-from fit_covid import lookup_prevalence
+from fit_covid import lookup_incidence
 from mgs import MGSData
 from pathogen_properties import *
 from tree import Tree
@@ -40,8 +40,14 @@ class TestPathogens(unittest.TestCase):
 
                 self.assertIsInstance(pathogen.pathogen_chars, PathogenChars)
 
+                saw_estimate = False
                 for estimate in pathogen.estimate_prevalences():
                     self.assertIsInstance(estimate, Prevalence)
+                    saw_estimate = True
+                for estimate in pathogen.estimate_incidences():
+                    self.assertIsInstance(estimate, IncidenceRate)
+                    saw_estimate = True
+                self.assertTrue(saw_estimate)
 
     def test_dates_set(self):
         for pathogen_name, pathogen in pathogens.pathogens.items():
@@ -345,31 +351,15 @@ class TestPopulations(unittest.TestCase):
         )
 
 
-class TestPrevalenceFromIncidence(unittest.TestCase):
-    def test_prevalence_from_incidences(self):
-        sd = SheddingDuration(days=5.6)
-        incidences = [
-            IncidenceRate(annual_infections_per_100k=i, date="2000-01-0%s" % i)
-            for i in range(1, 10)
-        ]
-        target_date = datetime.date(2000, 1, 9)
-        self.assertAlmostEqual(
-            (9 + 8 + 7 + 6 + 5 + 4 * 0.6) / 365,
-            sd.prevalence_from_incidences(
-                target_date, incidences
-            ).infections_per_100k,
-        )
-
-
 class TestCovid(unittest.TestCase):
-    def test_lookup_prevalence(self):
+    def test_lookup_incidence(self):
         pathogen = "sars_cov_2"
         bioproject = mgs.BioProject("PRJNA729801")  # Rothman
         mgs_data = MGSData.from_repo()
         samples = mgs_data.sample_attributes(
             bioproject, enrichment=mgs.Enrichment.VIRAL
         )
-        prevs = lookup_prevalence(samples, pathogen)
+        prevs = lookup_incidence(samples, pathogen)
         self.assertEqual(len(samples), len(prevs))
 
 


### PR DESCRIPTION
We've decided that in cases where the public health data gives us incidence we'll feed incidence into the model, and not try to convert to a prevalence first.  See https://docs.google.com/document/d/1qZ0mnqD4NgesSwp5hU2Nc5EXFkSSJkG3GQlPbtog5Wg/edit for full reasoning.

Example `summarize.py` output:
```
$ ./summarize.py hbv
hbv
   6.31 per 100k/y (United States; 2019)
   519.15 per 100k (United States; 2020)
```