### PR TITLE
Changed HAV underreporting scalar and removed unnecessary incidence variables.

### DIFF
--- a/pathogens/hav.py
+++ b/pathogens/hav.py
@@ -35,9 +35,9 @@ us_population_2018 = Population(
     source="https://data.census.gov/table?q=2018+us+population&t=Civilian+Population",
 )
 
-incidence_underreporting_scalar = Scalar(
+acute_underreporting_factor = Scalar(
     scalar=2,
-    confidence_interval=(1.4,2.2),
+    confidence_interval=(1.4, 2.2),
     coverage_probability=0.95,
     country="United States",
     source="https://www.cdc.gov/hepatitis/statistics/2018surveillance/pdfs/2018HepSurveillanceRpt.pdf?#page=8",

--- a/pathogens/hav.py
+++ b/pathogens/hav.py
@@ -36,33 +36,13 @@ us_population_2018 = Population(
 )
 
 incidence_underreporting_scalar = Scalar(
-    scalar=1 / 0.59,
-    confidence_interval=(
-        1 / 0.84,
-        1 / 0.32,
-    ),
+    scalar=2,
+    confidence_interval=(1.4,2.2),
     coverage_probability=0.95,
     country="United States",
-    source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4906888/#:~:text=Diagnosed%20hepatitis%20A,clear%20reporting%20responsibilities.",
+    source="https://www.cdc.gov/hepatitis/statistics/2018surveillance/pdfs/2018HepSurveillanceRpt.pdf?#page=8",
 )
 
-king_county_absolute_2017 = IncidenceAbsolute(
-    annual_infections=11,
-    country="United States",
-    state="Washington",
-    county="King County",
-    date="2017",
-    source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
-)
-
-king_county_absolute_2018 = IncidenceAbsolute(
-    annual_infections=14,
-    country="United States",
-    state="Washington",
-    county="King County",
-    date="2018",
-    source="https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28",
-)
 
 king_county_confirmed_cases_rate_2017 = IncidenceRate(
     annual_infections_per_100k=0.5,

--- a/pathogens/hav.py
+++ b/pathogens/hav.py
@@ -67,10 +67,8 @@ king_county_confirmed_cases_rate_2018 = IncidenceRate(
 def estimate_incidences() -> list[IncidenceRate]:
     return [
         us_incidence_absolute_2018.to_rate(us_population_2018),
-        king_county_confirmed_cases_rate_2017
-        * incidence_underreporting_scalar,
-        king_county_confirmed_cases_rate_2018
-        * incidence_underreporting_scalar,
+        king_county_confirmed_cases_rate_2017 * acute_underreporting_factor,
+        king_county_confirmed_cases_rate_2018 * acute_underreporting_factor,
     ]
 
 


### PR DESCRIPTION
Changed two things:

1. I replaced the underreporting scalar with a CDC underestimation scalar that we also used for HCV (https://www.cdc.gov/hepatitis/statistics/2018surveillance/pdfs/2018HepSurveillanceRpt.pdf?#page=8)
2. I deleted `king_county_absolute_2017` and `king_county_absolute_2017` incidences. They aren't used, as we already use the case rates per 100k, provided in the the same source (https://doh.wa.gov/sites/default/files/2023-01/420-004-CDAnnualReport2021.pdf?uid=642c448518316#page=28).