### PR TITLE
Fit Crits-Christoph MGS data

### DIFF
--- a/fit.py
+++ b/fit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
@@ -36,12 +37,14 @@ def print_summary(
 
 
 bioprojects = {
-    "crits-christoph": BioProject("PRJNA661613"),
+    "crits_christoph": BioProject("PRJNA661613"),
     "rothman": BioProject("PRJNA729801"),
 }
 
 
 def start():
+    outdir = Path("fits")
+    outdir.mkdir(exist_ok=True)
     mgs_data = MGSData.from_repo()
     predictor = "incidence"
     for pathogen_name in ["sars_cov_2", "norovirus"]:
@@ -53,7 +56,7 @@ def start():
             df = model.dataframe
             assert df is not None
             df.to_csv(
-                f"fits/{study}-{pathogen_name}.tsv.gz",
+                outdir / f"{study}-{pathogen_name}.tsv.gz",
                 sep="\t",
                 index=False,
                 compression="gzip",

--- a/test.py
+++ b/test.py
@@ -444,14 +444,18 @@ class TestStats(unittest.TestCase):
             stats.lookup_variable(self.attrs, [v3])
 
     def test_build_model(self):
-        bioproject = mgs.BioProject("PRJNA729801")  # Rothman
+        bioprojects = {
+            "crits-christoph": mgs.BioProject("PRJNA661613"),
+            "rothman": mgs.BioProject("PRJNA729801"),
+        }
         mgs_data = MGSData.from_repo()
         predictor = "incidence"
         for pathogen_name in ["sars_cov_2", "norovirus"]:
-            with self.subTest(pathogen=pathogen_name):
-                stats.build_model(
-                    mgs_data, bioproject, pathogen_name, predictor
-                )
+            for study, bioproject in bioprojects.items():
+                with self.subTest(study=study, pathogen=pathogen_name):
+                    stats.build_model(
+                        mgs_data, bioproject, pathogen_name, predictor
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fit model to Crits-Christoph as well as Rothman (for sars-cov-2 and norovirus). Resolves #114. Usage:

```
$ ./fit.py 2> /dev/null

------------------------------------------------------------
Crits-Christoph: sars_cov_2 relative abundance per incidence
------------------------------------------------------------
Posterior arithmetic mean:
2.6e-11
Posterior geometric mean:
2.0e-11
Posterior quantiles:
     5%        25%        50%        75%        95%
7.9e-12    1.3e-11    1.8e-11    2.8e-11    6.0e-11


----------------------------------------------------
Rothman: sars_cov_2 relative abundance per incidence
----------------------------------------------------
Posterior arithmetic mean:
6.0e-12
Posterior geometric mean:
5.8e-12
Posterior quantiles:
     5%        25%        50%        75%        95%
4.0e-12    5.0e-12    5.8e-12    6.7e-12    8.5e-12


-----------------------------------------------------------
Crits-Christoph: norovirus relative abundance per incidence
-----------------------------------------------------------
Posterior arithmetic mean:
1.4e-10
Posterior geometric mean:
1.1e-10
Posterior quantiles:
     5%        25%        50%        75%        95%
3.7e-11    6.8e-11    1.0e-10    1.6e-10    3.3e-10


---------------------------------------------------
Rothman: norovirus relative abundance per incidence
---------------------------------------------------
Posterior arithmetic mean:
1.1e-08
Posterior geometric mean:
1.1e-08
Posterior quantiles:
     5%        25%        50%        75%        95%
8.2e-09    9.7e-09    1.1e-08    1.3e-08    1.5e-08
```