### PR TITLE
Fix "Montogmery County" typo

### DIFF
--- a/mgs.py
+++ b/mgs.py
@@ -15,7 +15,7 @@ from tree import Tree
 MGS_REPO_DEFAULTS = {
     "user": "naobservatory",
     "repo": "mgs-pipeline",
-    "ref": "data-2023-05-22",
+    "ref": "data-2023-06-02",
 }
 
 

--- a/pathogens/sars_cov_2.py
+++ b/pathogens/sars_cov_2.py
@@ -38,7 +38,7 @@ target_counties = set(
         "Lawrence County, Ohio",
         "Licking County, Ohio",
         "Lucas County, Ohio",
-        "Montogmery County, Ohio",
+        "Montgomery County, Ohio",
         "Sandusky County, Ohio",
         "Summit County, Ohio",
         "Trumbull County, Ohio",


### PR DESCRIPTION
Bump MGS data tag and fix `target_counties`.

Should now match for all `sars_cov_2`:
```
$  ./check-matches.py | grep sars_cov_2

```