### PR TITLE
Divide predictions by taxids

### DIFF
--- a/fit.py
+++ b/fit.py
@@ -70,7 +70,6 @@ def start() -> None:
                 model = stats.build_model(
                     mgs_data,
                     bioproject,
-                    pathogen.pathogen_chars,
                     grouped_predictors,
                     taxids,
                 )

--- a/mgs.py
+++ b/mgs.py
@@ -18,6 +18,16 @@ MGS_REPO_DEFAULTS = {
     "ref": "data-2023-06-02",
 }
 
+BioProject = NewType("BioProject", str)
+Sample = NewType("Sample", str)
+
+
+rna_bioprojects = {
+    "crits_christoph": BioProject("PRJNA661613"),
+    "rothman": BioProject("PRJNA729801"),
+    "spurbeck": BioProject("PRJNA924011"),
+}
+
 
 @dataclass
 class GitHubRepo:
@@ -38,10 +48,6 @@ class GitHubRepo:
                     f"Failed to download {file_url}. "
                     f"Response status code: {response.status}"
                 )
-
-
-BioProject = NewType("BioProject", str)
-Sample = NewType("Sample", str)
 
 
 def load_bioprojects(repo: GitHubRepo) -> dict[BioProject, list[Sample]]:

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -493,3 +493,21 @@ class IncidenceAbsolute(Taggable):
 
 def prevalence_data_filename(filename):
     return os.path.join(os.path.dirname(__file__), "prevalence-data", filename)
+
+
+def by_taxids(
+    pathogen_chars: PathogenChars, predictors: list[Predictor]
+) -> dict[frozenset[TaxID], list[Predictor]]:
+    out: dict[frozenset[TaxID], list[Predictor]] = {}
+
+    for predictor in predictors:
+        taxids = pathogen_chars.taxids
+        if predictor.taxid:
+            taxids = frozenset([predictor.taxid])
+        assert taxids
+
+        if taxids not in out:
+            out[taxids] = []
+
+        out[taxids].append(predictor)
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [tool.black]
 line-length = 79
+
+[tool.isort]
+profile = "black"
+line_length = 79
+

--- a/stats.py
+++ b/stats.py
@@ -12,14 +12,7 @@ import stan  # type: ignore
 from scipy.stats import gamma, norm  # type: ignore
 
 from mgs import BioProject, Enrichment, MGSData, Sample, SampleAttributes
-from pathogen_properties import (
-    PathogenChars,
-    Predictor,
-    TaxID,
-    Variable,
-    by_taxids,
-)
-from pathogens import pathogens
+from pathogen_properties import Predictor, TaxID, Variable
 
 county_neighbors = {
     "Los Angeles County": [
@@ -104,7 +97,7 @@ def lookup_variables(
 
     if not qualities:
         return []
-    best_quality = max(quality for (quality, var) in qualities)
+    best_quality = max(quality for (quality, _) in qualities)
     return [var for (quality, var) in qualities if quality == best_quality]
 
 
@@ -244,7 +237,6 @@ def choose_predictor(predictors: list[Predictor]) -> Predictor:
 def build_model(
     mgs_data: MGSData,
     bioproject: BioProject,
-    pathogen_chars: PathogenChars,
     predictors: list[Predictor],
     taxids: frozenset[TaxID],
 ) -> Model:
@@ -256,13 +248,8 @@ def build_model(
             sample=s,
             attrs=attrs,
             viral_reads=mgs_data.viral_reads(bioproject, taxids)[s],
-            predictor=choose_predictor(
-                lookup_variables(attrs, grouped_predictors)
-            ),
+            predictor=choose_predictor(lookup_variables(attrs, predictors)),
         )
-        for taxids, grouped_predictors in by_taxids(
-            pathogen_chars, predictors
-        ).items()
         for s, attrs in samples.items()
     ]
     return Model(data=data)

--- a/test.py
+++ b/test.py
@@ -552,25 +552,26 @@ class TestPathogensMatchStudies(unittest.TestCase):
                 continue
 
             with self.subTest(pathogen=pathogen_name):
-                incidences = pathogen.estimate_incidences()
-                prevalences = pathogen.estimate_prevalences()
-
-                for study, bioproject in mgs.rna_bioprojects.items():
-                    with self.subTest(study=study):
-                        for (
-                            sample,
-                            sample_attributes,
-                        ) in mgs_data.sample_attributes(
-                            bioproject, enrichment=mgs.Enrichment.VIRAL
-                        ).items():
-                            with self.subTest(sample=sample):
-                                self.assertNotEqual(
-                                    stats.lookup_variables(
-                                        sample_attributes,
-                                        incidences + prevalences,
-                                    ),
-                                    [],
-                                )
+                for taxids, predictors in by_taxids(
+                    pathogen.pathogen_chars,
+                    pathogen.estimate_incidences()
+                    + pathogen.estimate_prevalences(),
+                ).items():
+                    for study, bioproject in mgs.rna_bioprojects.items():
+                        with self.subTest(study=study):
+                            for (
+                                sample,
+                                sample_attributes,
+                            ) in mgs_data.sample_attributes(
+                                bioproject, enrichment=mgs.Enrichment.VIRAL
+                            ).items():
+                                with self.subTest(sample=sample):
+                                    self.assertNotEqual(
+                                        stats.lookup_variables(
+                                            sample_attributes, predictors
+                                        ),
+                                        [],
+                                    )
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -8,7 +8,6 @@ import mgs
 import pathogens
 import populations
 import stats
-from mgs import MGSData, SampleAttributes
 from pathogen_properties import *
 from tree import Tree
 
@@ -220,8 +219,9 @@ class TestMGS(unittest.TestCase):
 
     def test_load_bioprojects(self):
         bps = mgs.load_bioprojects(self.repo)
-        # Rothman
-        self.assertIn(mgs.BioProject("PRJNA729801"), bps)
+        for study, bp in mgs.rna_bioprojects.items():
+            with self.subTest(study=study):
+                self.assertIn(bp, bps)
 
     def test_load_sample_attributes(self):
         samples = mgs.load_sample_attributes(self.repo)
@@ -286,13 +286,13 @@ class TestWeightedAverageByPopulation(unittest.TestCase):
 
 
 class TestMGSData(unittest.TestCase):
-    mgs_data = MGSData.from_repo()
-    bioproject = mgs.BioProject("PRJNA729801")  # Rothman
+    mgs_data = mgs.MGSData.from_repo()
+    bioproject = mgs.rna_bioprojects["rothman"]
     sample = mgs.Sample("SRR14530726")  # Random Rothman sample
     taxids = pathogens.pathogens["norovirus"].pathogen_chars.taxids
 
     def test_from_repo(self):
-        self.assertIsInstance(MGSData.from_repo(), MGSData)
+        self.assertIsInstance(mgs.MGSData.from_repo(), mgs.MGSData)
 
     def test_sample_attributes(self):
         samples = self.mgs_data.sample_attributes(self.bioproject)
@@ -434,7 +434,7 @@ class TestPopulations(unittest.TestCase):
 
 
 class TestStats(unittest.TestCase):
-    attrs = SampleAttributes(
+    attrs = mgs.SampleAttributes(
         country="United States",
         state="Pennsylvania",
         county="Allegheny County",
@@ -518,14 +518,10 @@ class TestStats(unittest.TestCase):
         self.assertEqual(stats.lookup_variables(self.attrs, [v6, v7]), [v7])
 
     def test_build_model(self):
-        bioprojects = {
-            "crits-christoph": mgs.BioProject("PRJNA661613"),
-            "rothman": mgs.BioProject("PRJNA729801"),
-        }
-        mgs_data = MGSData.from_repo()
+        mgs_data = mgs.MGSData.from_repo()
         for pathogen_name in ["sars_cov_2", "norovirus"]:
             pathogen = pathogens.pathogens[pathogen_name]
-            for study, bioproject in bioprojects.items():
+            for study, bioproject in mgs.rna_bioprojects.items():
                 with self.subTest(study=study, pathogen=pathogen_name):
                     for taxids, predictors in by_taxids(
                         pathogen.pathogen_chars, pathogen.estimate_incidences()
@@ -533,7 +529,6 @@ class TestStats(unittest.TestCase):
                         model = stats.build_model(
                             mgs_data,
                             bioproject,
-                            pathogen.pathogen_chars,
                             predictors,
                             taxids,
                         )
@@ -551,12 +546,6 @@ class TestPathogensMatchStudies(unittest.TestCase):
     def test_pathogens_match_studies(self):
         # Every RNA pathogen should have at least one estimate for every sample
         # in the projects we're working with.
-        rna_bioprojects = {
-            "crits_christoph": mgs.BioProject("PRJNA661613"),
-            "rothman": mgs.BioProject("PRJNA729801"),
-            "spurbeck": mgs.BioProject("PRJNA924011"),
-        }
-
         mgs_data = mgs.MGSData.from_repo()
         for pathogen_name, pathogen in pathogens.pathogens.items():
             if pathogen.pathogen_chars.na_type != NAType.RNA:
@@ -566,7 +555,7 @@ class TestPathogensMatchStudies(unittest.TestCase):
                 incidences = pathogen.estimate_incidences()
                 prevalences = pathogen.estimate_prevalences()
 
-                for study, bioproject in rna_bioprojects.items():
+                for study, bioproject in mgs.rna_bioprojects.items():
                     with self.subTest(study=study):
                         for (
                             sample,
@@ -578,9 +567,7 @@ class TestPathogensMatchStudies(unittest.TestCase):
                                 self.assertNotEqual(
                                     stats.lookup_variables(
                                         sample_attributes,
-                                        itertools.chain(
-                                            incidences, prevalences
-                                        ),
+                                        incidences + prevalences,
                                     ),
                                     [],
                                 )


### PR DESCRIPTION
When you call pathogen.estimate_incidences or pathogen.estimate_prevalences you can get estimates for a range of taxids.  For example, with Norovirus you can get ones for (a) Norovirus overall, (b) Group I, and (c) Group II.

To let modeling handle each group of taxids separately, add a converter method, by_taxids, that takes a list of estimates and breaks it down by which taxids they're for.

I've updated the stats.build_model interface for this, and test_build_model and fit.py accordingly, but I haven't verified that my changes to fit.py actually work.

Separately, I ran into an issue with stats.py where a long import line was getting formatted differently between black and isort, and needed to tell isort to use black's rules.