### PR TITLE
Don't emit zeros for any predictor

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -511,3 +511,14 @@ def by_taxids(
 
         out[taxids].append(predictor)
     return out
+
+
+# We don't want to predict zero of any pathogen, both because they almost never
+# go truely to zero and because modeling will be taking logs of our output.
+# Instead, consider our limit of detection to be a single event (an outbreak or
+# reported postive test), and when we have no recorded events figure there were
+# actually 0.1.
+#
+# It might be better to handle this in the modeling step, but by the time we
+# get to that point the granularity of the input data has been discarded.
+QUANTITY_WHEN_NONE_OBSERVED = 0.1

--- a/pathogens/influenza.py
+++ b/pathogens/influenza.py
@@ -228,6 +228,11 @@ def estimate_incidences() -> list[IncidenceRate]:
                 (FLU_A, positive_a),
                 (FLU_B, positive_b),
             ]:
+                adjusted_weekly_count = float(weekly_count)
+                if weekly_count == 0:
+                    # See comment on QUANTITY_WHEN_NONE_OBSERVED.
+                    adjusted_weekly_count = QUANTITY_WHEN_NONE_OBSERVED
+
                 if parsed_start.year <= 2019:
                     continue
 
@@ -236,7 +241,7 @@ def estimate_incidences() -> list[IncidenceRate]:
                     continue
 
                 incidence = IncidenceAbsolute(
-                    annual_infections=weekly_count * 52,
+                    annual_infections=adjusted_weekly_count * 52,
                     country="United States",
                     state=state,
                     date=parsed_start.isoformat(),

--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -196,6 +196,14 @@ def estimate_incidences() -> list[IncidenceRate]:
     us_daily_outbreaks = to_daily_counts(us_outbreaks)
 
     for year in range(HISTORY_START, DATA_END):
+        us_total_I = 0.0
+        us_total_II = 0.0
+        for month in range(1, 13):
+            us_total_I += us_outbreaks_I[year, month]
+            us_total_II += us_outbreaks_II[year, month]
+        assert us_total_I
+        assert us_total_II
+
         for month in range(1, 13):
             adjustment = Scalar(
                 scalar=us_daily_outbreaks[year, month]
@@ -217,11 +225,14 @@ def estimate_incidences() -> list[IncidenceRate]:
             # all infections.
             us_I = us_outbreaks_I[year, month]
             us_II = us_outbreaks_II[year, month]
-            if us_I + us_II:
+            if us_I and us_II:
                 group_I_fraction = us_I / (us_I + us_II)
                 group_II_fraction = us_II / (us_I + us_II)
             else:
-                group_I_fraction = group_II_fraction = 0
+                # Not enough records for this month to compute a ratio between
+                # I and II.  Fall back to the annual ratio.
+                group_I_fraction = us_total_I / (us_total_I + us_total_II)
+                group_II_fraction = us_total_II / (us_total_I + us_total_II)
 
             incidences.append(
                 dataclasses.replace(

--- a/test.py
+++ b/test.py
@@ -563,12 +563,16 @@ class TestPathogensMatchStudies(unittest.TestCase):
                                 bioproject, enrichment=mgs.Enrichment.VIRAL
                             ).items():
                                 with self.subTest(sample=sample):
-                                    self.assertNotEqual(
-                                        stats.lookup_variables(
-                                            sample_attributes, predictors
-                                        ),
-                                        [],
+                                    chosen_predictors = stats.lookup_variables(
+                                        sample_attributes, predictors
                                     )
+                                    self.assertNotEqual(chosen_predictors, [])
+
+                                    for predictor in chosen_predictors:
+                                        with self.subTest(predictor=predictor):
+                                            self.assertGreater(
+                                                predictor.get_data(), 0
+                                            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Zero is no good: we take the log of values, and if they're zero that explodes.

For Norovirus the issue was that we look at the I/II ratio and if either of those is zero then we'll emit a zero for that pathogen; in that case we can fall back to the annual average ratio.

For Influenza the issue was that some weeks had zero positive tests; in that case we somewhat unprincipledly treat it as if there were really 0.1 positive tests.

Fixes #148, with a test to verify it stays fixed.