### PR TITLE
Added a test to identify duplicate prevalences/incidences. Dropped duplicate HSV-1 and HSV-2 seroprevalence estimates.

### DIFF
--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -39,11 +39,6 @@ class Active(Enum):
     LATENT = "Latent"
 
 
-class Primary(Enum):
-    PRIMARY = "Primary"
-    SECONDARY = "Secondary"
-
-
 TaxID = NewType("TaxID", int)
 
 
@@ -330,7 +325,6 @@ class Prevalence(Predictor):
     """What fraction of people have this pathogen at some moment"""
 
     active: Active
-    primary: Optional[Primary] = None
     infections_per_100k: float
 
     def get_data(self) -> float:
@@ -343,7 +337,6 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
     def __truediv__(self, scalar: Scalar) -> "Prevalence":
@@ -353,7 +346,6 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
     def __add__(self: "Prevalence", other: "Prevalence") -> "Prevalence":
@@ -367,7 +359,6 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
     @staticmethod
@@ -398,7 +389,6 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
 
@@ -408,7 +398,6 @@ class PrevalenceAbsolute(Taggable):
 
     infections: float
     active: Active
-    primary: Optional[Primary] = None
 
     def to_rate(self, population: Population) -> Prevalence:
         self.assert_comparable(population)
@@ -419,7 +408,6 @@ class PrevalenceAbsolute(Taggable):
             active=self.active,
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
 
@@ -446,7 +434,6 @@ class IncidenceRate(Predictor):
     """What fraction of people get this pathogen annually"""
 
     annual_infections_per_100k: float
-    primary: Optional[Primary] = None
 
     def get_data(self) -> float:
         return self.annual_infections_per_100k
@@ -458,7 +445,6 @@ class IncidenceRate(Predictor):
             inputs=[self, scalar],
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
     @staticmethod
@@ -476,7 +462,6 @@ class IncidenceRate(Predictor):
             location_source=pairs[0][1],
             date_source=pairs[0][1],
             inputs=itertools.chain.from_iterable(pairs),
-            # HOW TO IMPLEMENT something like `primary=self.primary` here?
         )
 
 
@@ -485,7 +470,6 @@ class IncidenceAbsolute(Taggable):
     """How many people get this pathogen annually"""
 
     annual_infections: float
-    primary: Optional[Primary] = None
 
     def to_rate(self, population: Population) -> IncidenceRate:
         self.assert_comparable(population)
@@ -497,7 +481,6 @@ class IncidenceAbsolute(Taggable):
             inputs=[self, population],
             date_source=self,
             location_source=self,
-            primary=self.primary,
         )
 
     def __truediv__(self, other: "IncidenceAbsolute"):

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -39,6 +39,11 @@ class Active(Enum):
     LATENT = "Latent"
 
 
+class Primary(Enum):
+    PRIMARY = "Primary"
+    SECONDARY = "Secondary"
+
+
 TaxID = NewType("TaxID", int)
 
 
@@ -325,6 +330,7 @@ class Prevalence(Predictor):
     """What fraction of people have this pathogen at some moment"""
 
     active: Active
+    primary: Optional[Primary] = None
     infections_per_100k: float
 
     def get_data(self) -> float:
@@ -337,6 +343,7 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
     def __truediv__(self, scalar: Scalar) -> "Prevalence":
@@ -346,6 +353,7 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
     def __add__(self: "Prevalence", other: "Prevalence") -> "Prevalence":
@@ -359,6 +367,7 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
     @staticmethod
@@ -389,6 +398,7 @@ class Prevalence(Predictor):
             active=self.active,
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
 
@@ -398,6 +408,7 @@ class PrevalenceAbsolute(Taggable):
 
     infections: float
     active: Active
+    primary: Optional[Primary] = None
 
     def to_rate(self, population: Population) -> Prevalence:
         self.assert_comparable(population)
@@ -408,6 +419,7 @@ class PrevalenceAbsolute(Taggable):
             active=self.active,
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
 
@@ -434,6 +446,7 @@ class IncidenceRate(Predictor):
     """What fraction of people get this pathogen annually"""
 
     annual_infections_per_100k: float
+    primary: Optional[Primary] = None
 
     def get_data(self) -> float:
         return self.annual_infections_per_100k
@@ -445,6 +458,7 @@ class IncidenceRate(Predictor):
             inputs=[self, scalar],
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
     @staticmethod
@@ -462,6 +476,7 @@ class IncidenceRate(Predictor):
             location_source=pairs[0][1],
             date_source=pairs[0][1],
             inputs=itertools.chain.from_iterable(pairs),
+            # HOW TO IMPLEMENT something like `primary=self.primary` here?
         )
 
 
@@ -470,6 +485,7 @@ class IncidenceAbsolute(Taggable):
     """How many people get this pathogen annually"""
 
     annual_infections: float
+    primary: Optional[Primary] = None
 
     def to_rate(self, population: Population) -> IncidenceRate:
         self.assert_comparable(population)
@@ -481,6 +497,7 @@ class IncidenceAbsolute(Taggable):
             inputs=[self, population],
             date_source=self,
             location_source=self,
+            primary=self.primary,
         )
 
     def __truediv__(self, other: "IncidenceAbsolute"):

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -17,7 +17,7 @@ cdc_2015_2016_nhanes_estimate = Prevalence(
     infections_per_100k=0.478 * 100_000,
     confidence_interval=(0.4281 * 100_000, 0.5277 * 100_000),
     # This CDC estimate is based on the following NHANES data:
-    # https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm
+    # https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm#:~:text=YEARS%20%2D%2049%20YEARS-,LBXHE1%20%2D%20Herpes%20Simplex%20Virus%20Type%201,-Variable%20Name%3A
     country="United States",
     start_date="2015",
     end_date="2016",

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -20,6 +20,7 @@ cdc_2015_2016_nhanes_seroprevalence = Prevalence(
     end_date="2016",
     country="United States",
     active=Active.LATENT,
+    primary=Primary.SECONDARY,
     source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
 )
 cdc_2015_2016_nhanes_estimate = Prevalence(
@@ -29,6 +30,7 @@ cdc_2015_2016_nhanes_estimate = Prevalence(
     start_date="2015",
     end_date="2016",
     active=Active.LATENT,
+    primary=Primary.PRIMARY,
     source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf#page=1",
     methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
 )

--- a/pathogens/hsv_1.py
+++ b/pathogens/hsv_1.py
@@ -13,24 +13,15 @@ pathogen_chars = PathogenChars(
 )
 
 
-cdc_2015_2016_nhanes_seroprevalence = Prevalence(
-    infections_per_100k=0.496 * 100_000,
-    number_of_participants=3710,
-    start_date="2015",
-    end_date="2016",
-    country="United States",
-    active=Active.LATENT,
-    primary=Primary.SECONDARY,
-    source="https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm",
-)
 cdc_2015_2016_nhanes_estimate = Prevalence(
     infections_per_100k=0.478 * 100_000,
     confidence_interval=(0.4281 * 100_000, 0.5277 * 100_000),
+    # This CDC estimate is based on the following NHANES data:
+    # https://web.archive.org/web/20220707050306/https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm
     country="United States",
     start_date="2015",
     end_date="2016",
     active=Active.LATENT,
-    primary=Primary.PRIMARY,
     source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf#page=1",
     methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Data%20for%20this,p%20%3C%200.05",
 )
@@ -48,7 +39,6 @@ tear_and_saliva_prevalence = Prevalence(
 
 def estimate_prevalences() -> list[Prevalence]:
     return [
-        cdc_2015_2016_nhanes_seroprevalence,
         cdc_2015_2016_nhanes_estimate,
         tear_and_saliva_prevalence,
     ]

--- a/pathogens/hsv_2.py
+++ b/pathogens/hsv_2.py
@@ -16,18 +16,6 @@ pathogen_chars = PathogenChars(
 )
 
 
-cdc_2015_2016_nhanes_seroprevalence = Prevalence(
-    infections_per_100k=478 / 2815 * 100_000,
-    number_of_participants=2815,
-    country="United States",
-    start_date="2015",
-    end_date="2016",
-    active=Active.LATENT,
-    primary=Primary.SECONDARY,
-    source="https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm#:~:text=3710-,LBXHE2%20%2D%20Herpes%20Simplex%20Virus%20Type%202,-Variable%20Name%3A,",
-)
-
-
 cdc_2018_nhanes_estimate = PrevalenceAbsolute(
     infections=18.6 * 1e6,
     confidence_interval=(18.1 * 1e6, 19.0 * 1e6),
@@ -44,10 +32,11 @@ cdc_2015_2016_nhanes_estimate = Prevalence(
     infections_per_100k=0.121 * 100_000,
     country="United States",
     confidence_interval=(0.0966 * 100_000, 0.1495 * 100_000),
+    # This CDC estimate is based on the following NHANES data:
+    # https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm#:~:text=3710-,LBXHE2%20%2D%20Herpes%20Simplex%20Virus%20Type%202,-Variable%20Name%3A
     start_date="2015",
     end_date="2016",
     active=Active.LATENT,
-    primary=Primary.PRIMARY,
     source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf?#page=3",
     methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Estimates%20were%20calculated,p%20%3C%200.05.",
 )
@@ -106,7 +95,6 @@ us_population_2018_18_to_49yo = Population(
 
 def estimate_prevalences() -> list[Prevalence]:
     return [
-        cdc_2015_2016_nhanes_seroprevalence,
         cdc_2015_2016_nhanes_estimate,
         cdc_2018_nhanes_estimate.to_rate(us_population_2018_18_to_49yo),
     ]

--- a/pathogens/hsv_2.py
+++ b/pathogens/hsv_2.py
@@ -23,6 +23,7 @@ cdc_2015_2016_nhanes_seroprevalence = Prevalence(
     start_date="2015",
     end_date="2016",
     active=Active.LATENT,
+    primary=Primary.SECONDARY,
     source="https://wwwn.cdc.gov/Nchs/Nhanes/2015-2016/HSV_I.htm#:~:text=3710-,LBXHE2%20%2D%20Herpes%20Simplex%20Virus%20Type%202,-Variable%20Name%3A,",
 )
 
@@ -46,6 +47,7 @@ cdc_2015_2016_nhanes_estimate = Prevalence(
     start_date="2015",
     end_date="2016",
     active=Active.LATENT,
+    primary=Primary.PRIMARY,
     source="https://www.cdc.gov/nchs/data/databriefs/db304_table.pdf?#page=3",
     methods="https://www.cdc.gov/nchs/products/databriefs/db304.htm#:~:text=Estimates%20were%20calculated,p%20%3C%200.05.",
 )

--- a/test.py
+++ b/test.py
@@ -89,20 +89,18 @@ class TestPathogens(unittest.TestCase):
                         pathogen.estimate_incidences(),
                     ),
                 ]:
-                    seen = set()
                     for taxids, estimates in by_taxids(
                         pathogen.pathogen_chars, predictors
                     ).items():
+                        seen = set()
                         for estimate in estimates:
                             key = (
                                 estimate.get_dates(),
                                 estimate.summarize_location(),
-                                taxids,
-                                estimate.primary,
                             )
                             if key in seen:
                                 self.fail(
-                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Drop duplicate estimates or flag as primary/secondary."
+                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}."
                                 )
                             seen.add(key)
 

--- a/test.py
+++ b/test.py
@@ -102,7 +102,8 @@ class TestPathogens(unittest.TestCase):
                             )
                             if key in seen:
                                 self.fail(
-                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Drop duplicate estimates or flag as primary/secondary."
+                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. 
+                                    Drop duplicate estimates or flag as primary/secondary."
                                 )
                             seen.add(key)
 

--- a/test.py
+++ b/test.py
@@ -102,7 +102,7 @@ class TestPathogens(unittest.TestCase):
                             )
                             if key in seen:
                                 self.fail(
-                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Do you want to differentiate parallel estimates by primary/secondary?"
+                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Drop duplicate estimates or flag as primary/secondary."
                                 )
                             seen.add(key)
 

--- a/test.py
+++ b/test.py
@@ -76,6 +76,36 @@ class TestPathogens(unittest.TestCase):
                                 pathogen.pathogen_chars.taxids, taxids
                             )
 
+    def test_duplicate_estimates(self):
+        for pathogen_name, pathogen in pathogens.pathogens.items():
+            with self.subTest(pathogen=pathogen_name):
+                for label, predictors in [
+                    (
+                        "prevalence",
+                        pathogen.estimate_prevalences(),
+                    ),
+                    (
+                        "incidence",
+                        pathogen.estimate_incidences(),
+                    ),
+                ]:
+                    seen = set()
+                    for taxids, estimates in by_taxids(
+                        pathogen.pathogen_chars, predictors
+                    ).items():
+                        for estimate in estimates:
+                            key = (
+                                estimate.get_dates(),
+                                estimate.summarize_location(),
+                                taxids,
+                                estimate.primary,
+                            )
+                            if key in seen:
+                                self.fail(
+                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Do you want to differentiate parallel estimates by primary/secondary?"
+                                )
+                            seen.add(key)
+
 
 class TestMMWRWeek(unittest.TestCase):
     def test_mmwr_week(self):

--- a/test.py
+++ b/test.py
@@ -102,8 +102,7 @@ class TestPathogens(unittest.TestCase):
                             )
                             if key in seen:
                                 self.fail(
-                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. 
-                                    Drop duplicate estimates or flag as primary/secondary."
+                                    f"Duplicate {label} estimate found for {pathogen_name}: {key}. Drop duplicate estimates or flag as primary/secondary."
                                 )
                             seen.add(key)
 


### PR DESCRIPTION
We sometimes had multiple prevalence/incidence estimates for the same pathogen, time, and place. This can lead to errors in downstream analyses, and we instead want to either combine estimates, or drop estimates, with the goal of having only one estimate per time, place, and pathogen.

This PR adds a test, separately spotting duplicate prevalence and incidence estimates. It also drops duplicate estimates for HSV-1 and HSV-2, which we identified through this test.