### PR TITLE
Simon hep b c extension

### DIFF
--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -41,42 +41,6 @@ cdc_acute_underreporting_factor_2020 = Scalar(
 )
 
 
-cdc_estimated_acute_2019 = IncidenceAbsolute(
-    annual_infections=20_700,
-    # During 2019, a total of 3,192 acute hepatitis B cases were reported to
-    # CDC, resulting in 20,700 estimated infections (95% CI: 11,800–50,800)
-    # after adjusting for case underascertainment and underreporting.
-    confidence_interval=(11_800, 50_800),  # 95% Bootstrap Confidence Interval
-    coverage_probability=0.95,
-    country="United States",
-    # I picked 2019 rates, as estimated rates in 2020 were 30% lower, even
-    # while deaths stayed the same, pointing to undercounting due to
-    # COVID-19: https://www.cdc.gov/hepatitis/statistics/2020surveillance/introduction/national-profile.htm#:~:text=hepatitis%20B%20transmission.-,Data%20from%20death%20certificates%20filed%20in%20the%20vital%20records%20offices%20of,same%20as%20the%20rate%20during%202019%20(0.42%20deaths%20per%20100%2C000%20population).,-Hepatitis%20C
-    date="2019",
-    source="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=20%2C700%20estimated%20infections%20(95%25%20CI%3A%2011%2C800%E2%80%9350%2C800)",
-    methods="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=To%20account%20for,CI%3A%2011.0%E2%80%9347.4).",
-)
-
-
-estimated_chronic_prevalence_us_2020 = PrevalenceAbsolute(
-    infections=1_721_027,
-    # This is their mid estimate in table 4, second to last row. The estimate
-    # listed in their paper and on the last line of the table doesn't add up.
-    # They say they added 303'237 (point estimate US-born) + 1'076'069 (lower
-    # estimate Foreign-born) + 72'013 (point estimate Non-NHANES). But that
-    # adds up to 1'450'320, which isn't the number they give (1.59M). We are
-    # contacting the authors on this.
-    confidence_interval=(1_249_055, 2_491_435),  # These numbers represent a
-    # "low" and "high" estimate, labels that aren't further defined. Numbers
-    # can be found in table 4, second to last row.
-    active=Active.LATENT,
-    country="United States",
-    date="2020",
-    source="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Table%204.%3A%20Estimated%20prevalence%20of%20chronic%20HBV%20in%20the%20United%20Statesa",
-    methods="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Panel%20members%20researched,in%20the%20US.",
-)
-
-
 ohio_reported_acute_2021 = IncidenceRate(
     # This source reports both acute and total (acute+chronic) reported incidence.
     # We only report acute incidence here, as chronic prevalence is covered by

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -104,9 +104,12 @@ def estimate_prevalences() -> list[Prevalence]:
 
 def estimate_incidences() -> list[IncidenceRate]:
     # Before the COVID-19 pandemic, acute HBV incidence has stayed
-    # approximately cosntant: (https://www.cdc.gov/hepatitis/statistics/
-    # 2019surveillance/Figure2.1.htm). We can, therefore, can estimate 2020
-    # and 2021 incidence from 2019 incidence.
+    # approximately constant: (https://www.cdc.gov/hepatitis/statistics/
+    # 2019surveillance/Figure2.1.htm). We can, therefore, estimate 2020
+    # and 2021 incidence from 2019 incidence. We don't expect Hep B to be
+    # affected by COVID-19 itself as strongly, given that it is transmitted
+    # through sexual contact and injection drug use, which are less affected
+    # by social distancing.
     acute_2019 = estimated_acute_2019.to_rate(us_population_2019)
 
     acute_2020 = dataclasses.replace(

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -90,24 +90,23 @@ estimated_chronic_us_2020 = PrevalenceAbsolute(
 
 def estimate_prevalences() -> list[Prevalence]:
     chronic_2020 = estimated_chronic_us_2020.to_rate(us_population(year=2020))
-    # Hep B acute and chronic cases should be approximately constant, so we
-    # can use chronic 2020 estimates for 2019 and 2021, and acute 2019
-    # estimates for 2020 and 2021.
-    chronic_2019 = dataclasses.replace(
-        chronic_2020, date_source=Variable(date="2019")
-    )
+    # Hep B chronic cases should be approximately constant, so we
+    # can use chronic 2020 estimates for 2021.
     chronic_2021 = dataclasses.replace(
         chronic_2020, date_source=Variable(date="2021")
     )
 
     return [
-        chronic_2019,
         chronic_2020,
         chronic_2021,
     ]
 
 
 def estimate_incidences() -> list[IncidenceRate]:
+    # Before the COVID-19 pandemic, acute HBV incidence has stayed
+    # approximately cosntant: (https://www.cdc.gov/hepatitis/statistics/
+    # 2019surveillance/Figure2.1.htm). We can, therefore, can estimate 2020
+    # and 2021 incidence from 2019 incidence.
     acute_2019 = estimated_acute_2019.to_rate(us_population_2019)
 
     acute_2020 = dataclasses.replace(

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -91,7 +91,8 @@ estimated_chronic_us_2020 = PrevalenceAbsolute(
 def estimate_prevalences() -> list[Prevalence]:
     chronic_2020 = estimated_chronic_us_2020.to_rate(us_population(year=2020))
     # Hep B acute and chronic cases should be approximately constant, so we
-    # can use 2019 acute estimates for 2020 and 2021.
+    # can use chronic 2020 estimates for 2019 and 2021, and acute 2019
+    # estimates for 2020 and 2021.
     chronic_2019 = dataclasses.replace(
         chronic_2020, date_source=Variable(date="2019")
     )

--- a/pathogens/hbv.py
+++ b/pathogens/hbv.py
@@ -77,7 +77,7 @@ estimated_chronic_prevalence_us_2020 = PrevalenceAbsolute(
 )
 
 
-ohio_reported_acute_incidence_2021 = IncidenceRate(
+ohio_reported_acute_2021 = IncidenceRate(
     # This source reports both acute and total (acute+chronic) reported incidence.
     # We only report acute incidence here, as chronic prevalence is covered by
     # the national estimate.
@@ -89,16 +89,71 @@ ohio_reported_acute_incidence_2021 = IncidenceRate(
     source="https://odh.ohio.gov/know-our-programs/viral-hepatitis/data-statistics/hbv_5yr_report",
 )
 
+estimated_acute_2019 = IncidenceAbsolute(
+    annual_infections=20_700,
+    # During 2019, a total of 3,192 acute hepatitis B cases were reported to
+    # CDC, resulting in 20,700 estimated infections (95% CI: 11,800–50,800)
+    # after adjusting for case underascertainment and underreporting.
+    confidence_interval=(11_800, 50_800),  # 95% Bootstrap Confidence Interval
+    coverage_probability=0.95,
+    country="United States",
+    # I picked 2019 rates, as estimated rates in 2020 were 30% lower, even
+    # while deaths stayed the same, pointing to undercounting due to
+    # COVID-19: https://www.cdc.gov/hepatitis/statistics/2020surveillance/introduction/national-profile.htm#:~:text=hepatitis%20B%20transmission.-,Data%20from%20death%20certificates%20filed%20in%20the%20vital%20records%20offices%20of,same%20as%20the%20rate%20during%202019%20(0.42%20deaths%20per%20100%2C000%20population).,-Hepatitis%20C
+    date="2019",
+    source="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=20%2C700%20estimated%20infections%20(95%25%20CI%3A%2011%2C800%E2%80%9350%2C800)",
+    methods="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=To%20account%20for,CI%3A%2011.0%E2%80%9347.4).",
+)
+
+estimated_chronic_us_2020 = PrevalenceAbsolute(
+    infections=1_721_027,
+    # This is their mid estimate in table 4, second to last row. The estimate
+    # listed in their paper and on the last line of the table doesn't add up.
+    # They say they added 303'237 (point estimate US-born) + 1'076'069 (lower
+    # estimate Foreign-born) + 72'013 (point estimate Non-NHANES). But that
+    # adds up to 1'450'320, which isn't the number they give (1.59M). We are
+    # contacting the authors on this.
+    confidence_interval=(1_249_055, 2_491_435),  # These numbers represent a
+    # "low" and "high" estimate, labels that aren't further defined. Numbers
+    # can be found in table 4, second to last row.
+    active=Active.LATENT,
+    country="United States",
+    date="2020",
+    source="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Table%204.%3A%20Estimated%20prevalence%20of%20chronic%20HBV%20in%20the%20United%20Statesa",
+    methods="https://journals.lww.com/ajg/fulltext/2020/09000/prevalence_of_chronic_hepatitis_b_virus_infection.20.aspx#:~:text=Panel%20members%20researched,in%20the%20US.",
+)
+
 
 def estimate_prevalences() -> list[Prevalence]:
+    chronic_2020 = estimated_chronic_us_2020.to_rate(us_population(year=2020))
+    # Hep B acute and chronic cases should be approximately constant, so we
+    # can use 2019 acute estimates for 2020 and 2021.
+    chronic_2019 = dataclasses.replace(
+        chronic_2020, date_source=Variable(date="2019")
+    )
+    chronic_2021 = dataclasses.replace(
+        chronic_2020, date_source=Variable(date="2021")
+    )
+
     return [
-        estimated_chronic_prevalence_us_2020.to_rate(us_population(year=2020))
+        chronic_2019,
+        chronic_2020,
+        chronic_2021,
     ]
 
 
 def estimate_incidences() -> list[IncidenceRate]:
+    acute_2019 = estimated_acute_2019.to_rate(us_population_2019)
+
+    acute_2020 = dataclasses.replace(
+        acute_2019, date_source=Variable(date="2020")
+    )
+    acute_2021 = dataclasses.replace(
+        acute_2019, date_source=Variable(date="2021")
+    )
     return [
-        cdc_estimated_acute_2019.to_rate(us_population_2019),
-        ohio_reported_acute_incidence_2021
-        * cdc_acute_underreporting_factor_2020,
+        acute_2019,
+        acute_2020,
+        acute_2021,
+        ohio_reported_acute_2021 * cdc_acute_underreporting_factor_2020,
     ]

--- a/pathogens/hcv.py
+++ b/pathogens/hcv.py
@@ -8,6 +8,14 @@ pathogen_chars = PathogenChars(
     taxid=TaxID(11103),
 )
 
+us_population_2019 = Population(
+    people=328.2 * 1e6,
+    country="United States",
+    date="2019",
+    source="https://data.census.gov/table?q=us+population+2019&tid=ACSDP1Y2019.DP05",
+)
+
+
 # Data below is from the Ohio Department of Health. They give case rates,
 # which are "shown per 100,000 persons and were calculated using census
 # estimates for that year, except 2021 is using 2020 census."
@@ -34,27 +42,7 @@ reported_acute_ohio_2021 = IncidenceRate(
 )
 
 
-cdc_estimated_acute_44_us_states_2020 = IncidenceRate(
-    annual_infections_per_100k=1.5,
-    # The CDC gives a CI for its 66,700 estimated infections (95% CI:
-    # 52_700–227_400), but not its rate (1.5 cases per 100k). I adopted their
-    # absolute count CI to also get a CI for the rate.
-    confidence_interval=(
-        (52_700 / 66_700) * 1.5,
-        (227_400 / 66_700) * 1.5,
-    ),  # 95% CI
-    coverage_probability=0.95,
-    date="2020",
-    country="United States",
-    # Specifically, this estimate is for 44 US states, as six states and the
-    # District of Columbia did not report data, see here for a list of
-    # non-reporters:
-    # "https://www.cdc.gov/hepatitis/statistics/2020surveillance/introduction/technical-notes.htm#:~:text=Chronic%20hepatitis%20B-,Acute%20hepatitis%20C,-Chronic%20hepatitis%20C"
-    source="https://www.cdc.gov/hepatitis/statistics/2020surveillance/introduction/national-profile.htm#:~:text=During%202020%2C%20a%20total%20of%204%2C798%20acute%20hepatitis%20C%20cases%20were%20reported%20to%20CDC%20from%2044%20states%2C%20corresponding%20to%2066%2C700%20estimated%20infections%20(95%25%20CI%3A%2052%2C700%E2%80%93227%2C400)",
-)
-
-
-estimated_current_infection_us_2013_2016 = Prevalence(
+estimated_chronic_us_2013_2016 = Prevalence(
     # [...] we analyzed 2013-2016 data from the National Health
     # and Nutrition Examination Survey (NHANES) to estimate the prevalence of
     # HCV in the noninstitutionalized civilian population and used a
@@ -79,12 +67,20 @@ estimated_current_infection_us_2013_2016 = Prevalence(
     active=Active.LATENT,
 )
 
-us_adult_population_2016 = Population(
-    people=249_448_772,
-    source="https://data.census.gov/table?q=2016+population+us&tid=ACSDP1Y2016.DP05",
-    date="2016",
+cdc_estimated_acute_2019 = IncidenceAbsolute(
+    annual_infections=57_500,
+    # During 2019, a total of 4,136 acute hepatitis C cases were reported to
+    # CDC, corresponding to 57,500 estimated infections (95% CI: 45,500–196,
+    # 000).
+    # We do not use 2020 estimated incidence, as the underascertainment factor
+    # with which the CDC gets from reported to estimated cases wasn't changed
+    # in 2020, even though the pandemic should have influenced case reporting
+    # significantly.
+    confidence_interval=(45_500, 196_000),  # 95% CI
+    coverage_probability=0.95,
+    date="2019",
     country="United States",
-    tag="us-2013-2016",
+    source="https://www.cdc.gov/hepatitis/statistics/2019surveillance/Introduction.htm#Technical:~:text=During%202019%2C%20a%20total%20of%204%2C136%20acute%20hepatitis%20C%20cases%20were%20reported%20to%20CDC%2C%20corresponding%20to%2057%2C500%20estimated%20infections%20(95%25%20CI%3A%2045%2C500%E2%80%93196%2C000))",
 )
 
 acute_underreporting_factor = Scalar(
@@ -146,10 +142,23 @@ OHIO_COUNTY_ESTIMATES_SOURCE = "https://odh.ohio.gov/wps/wcm/connect/gov/ec0dec2
 
 
 def estimate_incidences():
+    # Hep C acute cases should be approximately constant, so we
+    # can use 2019 acute estimates for 2020 and 2021.
+
+    acute_2019 = cdc_estimated_acute_2019.to_rate(us_population_2019)
+    acute_2020 = dataclasses.replace(
+        acute_2019, date_source=Variable(date="2020")
+    )
+    acute_2021 = dataclasses.replace(
+        acute_2019, date_source=Variable(date="2021")
+    )
+
     estimates = [
+        acute_2019,
+        acute_2020,
+        acute_2021,
         reported_acute_ohio_2020 * (acute_underreporting_factor),
         reported_acute_ohio_2021 * (acute_underreporting_factor),
-        cdc_estimated_acute_44_us_states_2020,
     ]
     for county in ohio_counties_case_rates:
         for year in ohio_counties_case_rates[county]:
@@ -170,7 +179,7 @@ def estimate_incidences():
 
 
 def estimate_prevalences() -> list[Prevalence]:
-    estimates = [
-        estimated_current_infection_us_2013_2016,
-    ]
+    # This estimate being from 2016, I (Simon) do not want to transfer it to
+    # 2019-202 without first doing further research.
+    estimates = [estimated_chronic_us_2013_2016]
     return estimates

--- a/pathogens/hcv.py
+++ b/pathogens/hcv.py
@@ -184,7 +184,7 @@ def estimate_prevalences() -> list[Prevalence]:
     # not to a level that would change the chronic rate by much. We thus
     # extrapolate the 2016 rate to 2020 and 2021.
     chronic_2020 = dataclasses.replace(
-        estimated_chronic_us_2013_2016, date_source=Variable(date="2021")
+        estimated_chronic_us_2013_2016, date_source=Variable(date="2020")
     )
 
     chronic_2021 = dataclasses.replace(

--- a/pathogens/hcv.py
+++ b/pathogens/hcv.py
@@ -67,6 +67,7 @@ estimated_chronic_us_2013_2016 = Prevalence(
     active=Active.LATENT,
 )
 
+
 cdc_estimated_acute_2019 = IncidenceAbsolute(
     annual_infections=57_500,
     # During 2019, a total of 4,136 acute hepatitis C cases were reported to
@@ -179,7 +180,15 @@ def estimate_incidences():
 
 
 def estimate_prevalences() -> list[Prevalence]:
-    # This estimate being from 2016, I (Simon) do not want to transfer it to
-    # 2019-202 without first doing further research.
-    estimates = [estimated_chronic_us_2013_2016]
+    # Estimated acute cases have increased slighly since 2016 (https://www.cdc.gov/hepatitis/statistics/2020surveillance/hepatitis-c/figure-3.1.htm), but
+    # not to a level that would change the chronic rate by much. We thus
+    # extrapolate the 2016 rate to 2020 and 2021.
+    chronic_2020 = dataclasses.replace(
+        estimated_chronic_us_2013_2016, date_source=Variable(date="2021")
+    )
+
+    chronic_2021 = dataclasses.replace(
+        estimated_chronic_us_2013_2016, date_source=Variable(date="2021")
+    )
+    estimates = [estimated_chronic_us_2013_2016, chronic_2020, chronic_2021]
     return estimates


### PR DESCRIPTION
- Switched to using the acute Hep C CDC estimate from 2019 instead of the 2020 estimate. The CDC underreporting factors in 2020 for Hepatitis B and C were the same as in 2019, which seems wrong given the pandemic should have impacted case reporting quite a bit.
- Extrapolated acute and chronic Hep B, and acute Hep C estimates to 2019-2021.