### PR TITLE
Add stubs for BKV, JCV, MCV, and AAV2

### DIFF
--- a/pathogens/aav2.py
+++ b/pathogens/aav2.py
@@ -1,0 +1,31 @@
+import dataclasses
+
+from pathogen_properties import *
+
+background = """Adeno-associated virus 2 is a small replication-defective
+virus"""
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.DNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=TaxID(10804),
+)
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    stub_estimate = Prevalence(
+        # Completely made up, checking in stub for model testing.
+        infections_per_100k=50_000,
+        active=Active.LATENT,
+        country="United States",
+    )
+    return [
+        # This pathogen should be close to constant, so extrapolate to 2020 and
+        # 2021.
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2020")),
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2021")),
+    ]
+
+
+def estimate_incidences():
+    return []

--- a/pathogens/bkv.py
+++ b/pathogens/bkv.py
@@ -1,0 +1,31 @@
+import dataclasses
+
+from pathogen_properties import *
+
+background = """BK virus is a common virus which has minimal impact in
+immunocompetent humans"""
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.DNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=TaxID(1891762),
+)
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    stub_estimate = Prevalence(
+        # Completely made up, checking in stub for model testing.
+        infections_per_100k=50_000,
+        active=Active.LATENT,
+        country="United States",
+    )
+    return [
+        # This pathogen should be close to constant, so extrapolate to 2020 and
+        # 2021.
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2020")),
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2021")),
+    ]
+
+
+def estimate_incidences():
+    return []

--- a/pathogens/jcv.py
+++ b/pathogens/jcv.py
@@ -1,0 +1,31 @@
+import dataclasses
+
+from pathogen_properties import *
+
+background = """JC virus is a common virus which has minimal impact in
+immunocompetent humans"""
+
+pathogen_chars = PathogenChars(
+    na_type=NAType.DNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=TaxID(10632),
+)
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    stub_estimate = Prevalence(
+        # Completely made up, checking in stub for model testing.
+        infections_per_100k=50_000,
+        active=Active.LATENT,
+        country="United States",
+    )
+    return [
+        # This pathogen should be close to constant, so extrapolate to 2020 and
+        # 2021.
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2020")),
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2021")),
+    ]
+
+
+def estimate_incidences():
+    return []

--- a/pathogens/mcv.py
+++ b/pathogens/mcv.py
@@ -1,0 +1,30 @@
+import dataclasses
+
+from pathogen_properties import *
+
+background = """Merkel cell polyomavirus is an extremely common virus that is
+suspected to occasionally cause skin cancer."""
+pathogen_chars = PathogenChars(
+    na_type=NAType.DNA,
+    enveloped=Enveloped.NON_ENVELOPED,
+    taxid=TaxID(493803),
+)
+
+
+def estimate_prevalences() -> list[Prevalence]:
+    stub_estimate = Prevalence(
+        # Completely made up, checking in stub for model testing.
+        infections_per_100k=50_000,
+        active=Active.LATENT,
+        country="United States",
+    )
+    return [
+        # This pathogen should be close to constant, so extrapolate to 2020 and
+        # 2021.
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2020")),
+        dataclasses.replace(stub_estimate, date_source=Variable(date="2021")),
+    ]
+
+
+def estimate_incidences():
+    return []


### PR DESCRIPTION
We are planning to add estimates for these four viruses (https://twist.com/a/197793/ch/661244/t/4455246/) and it would be helpful to test them in modeling at this stage.  We expect their population prevalence to be constant over time, which means modeling will only be off by a (very important eventually but not important right now) constant factor.