### PR TITLE
Simon jc virus

### DIFF
--- a/pathogens/jcv.py
+++ b/pathogens/jcv.py
@@ -1,4 +1,3 @@
-
 from pathogen_properties import *
 
 background = """JC virus is a polyomavirus that is ubiquitous in the human population, staying latent in the body after infection. It is the causative agent of a rare but often fatal demyelinating disease of the central nervous system. It most likely spreads through feces or urine."""

--- a/pathogens/jcv.py
+++ b/pathogens/jcv.py
@@ -49,6 +49,8 @@ us_2007_seroprevalence = Prevalence(
     infections_per_100k=0.39 * 100_000,
     # "We found the seroprevalence (+/− 1%) in healthy adult blood donors
     # (1501) was [...] JCV (39%)"
+    # Note that these were blood donors, and thus aren't representative of the
+    # general population.
     number_of_participants=1501,
     # Plasma samples from healthy adult blood donors were obtained (May and June, 2007) from Bonfils Blood Center (Denver), and pediatric plasma samples were obtained from The Children's Hospital (Denver)
     country="United States",


### PR DESCRIPTION
Adds a new estimate for JC Virus, one of three polyomaviruses that we want to cover due to their high prevalence and their presence in RNA sequencing data.

Next week, I will improve this estimate by adjusting US data by age cohort size (#164).