### PR TITLE
norovirus: follow flu in only listing GI and GII, not combined

### DIFF
--- a/pathogens/norovirus.py
+++ b/pathogens/norovirus.py
@@ -8,15 +8,13 @@ from pathogen_properties import *
 background = """Norovirus is a GI infection, mostly spread through personal
 contact."""
 
-NOROVIRUS = TaxID(142786)
 NOROVIRUS_GROUP_I = TaxID(122928)
 NOROVIRUS_GROUP_II = TaxID(122929)
 
 pathogen_chars = PathogenChars(
     na_type=NAType.RNA,
     enveloped=Enveloped.NON_ENVELOPED,
-    taxid=TaxID(NOROVIRUS),
-    subtaxids=frozenset((NOROVIRUS_GROUP_I, NOROVIRUS_GROUP_II)),
+    taxids=frozenset((NOROVIRUS_GROUP_I, NOROVIRUS_GROUP_II)),
 )
 
 # We're using Scallan 2011
@@ -216,8 +214,6 @@ def estimate_incidences() -> list[IncidenceRate]:
                 pre_covid_national_incidence * adjustment,
                 date_source=adjustment,
             )
-
-            incidences.append(adjusted_national_incidence)
 
             # Assume that all Norovirus infections are either Group I or II,
             # which is very close (see assertion above).  Also assume the


### PR DESCRIPTION
Not much sense in having three rows on plots for Norovirus when GI and GII have almost all the information (very few Norovirus reads are not classified as GI or GII)