### PR TITLE
Pin `pydantic` to 1.10

### DIFF
--- a/mgs.py
+++ b/mgs.py
@@ -72,7 +72,7 @@ class SampleAttributes(BaseModel):
     # Fixme: Not all the dates are real dates
     date: date | str
     reads: int
-    enrichment: Optional[Enrichment]
+    enrichment: Optional[Enrichment] = None
     method: Optional[str] = None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pystan~=3.6
 numpy
-pydantic
+pydantic~=1.10
 pandas
 matplotlib
 seaborn


### PR DESCRIPTION
`pydantic` released version 2.0 recently, which breaks our `SampleAttributes` parsing code. Pin to version 1.10 for now.