### PR TITLE
Extrapolated 2006 Dutch CMV seroprevalence to Denmark 2015-2018.

### DIFF
--- a/pathogens/cmv.py
+++ b/pathogens/cmv.py
@@ -38,12 +38,13 @@ dutch_seroprevalence_2006 = Prevalence(
     infections_per_100k=0.456 * 100_000,
     confidence_interval=(0.419 * 100_000, 0.493 * 100_000),  # 95% CI
     active=Active.LATENT,
-    number_of_participants=6249,
+    number_of_participants=6382,
     # "This study used information from the PIENTER2 project, a crosssectional
     # population-based serum bank established in 2006–2007.[...]
     # A total of 19,781 individuals, including 2558 non-Western migrants, were
     # invited to complete a questionnaire and donate a blood sample. Serum
-    # samples were obtained from 6386 individuals (32%)."
+    # samples were obtained from 6386 individuals (32%). Sufficient serum to
+    # test for CMV antibodies was available from 6382 participants.
     source="https://doi.org/10.1016/j.jcv.2014.11.033",  # Page 4, heading 4.2
     country="Netherlands",
     date="2006",

--- a/pathogens/cmv.py
+++ b/pathogens/cmv.py
@@ -32,7 +32,7 @@ de_adult_seroprevalence_1998 = Prevalence(
     source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6059406/#:~:text=Overall%20CMV%20seroprevalence,Germany%20in%20women",
 )
 
-dutch_seroprevalence_2006 = Prevalence(
+nl_seroprevalence_2006 = Prevalence(
     # "The CMV seroprevalence in the general population (6 months–79 years)
     # was 45.6%.""
     infections_per_100k=0.456 * 100_000,
@@ -105,20 +105,20 @@ def estimate_prevalences():
     # Note the limitation noted in Issue #198: https://github.com/
     # naobservatory/p2ra/issues/198
     dk_2015 = dataclasses.replace(
-        dutch_seroprevalence_2006,
+        nl_seroprevalence_2006,
         date_source=Variable(date="2015"),
         location_source=Variable(country="Denmark"),
     )
     dk_2016 = dataclasses.replace(
-        dk_2015,
+        nl_seroprevalence_2006,
         date_source=Variable(date="2016"),
     )
     dk_2017 = dataclasses.replace(
-        dk_2015,
+        nl_seroprevalence_2006,
         date_source=Variable(date="2017"),
     )
     dk_2018 = dataclasses.replace(
-        dk_2015,
+        nl_seroprevalence_2006,
         date_source=Variable(date="2018"),
     )
     # CMV should be close to constant, so extrapolate from 2003-2010 to
@@ -141,7 +141,7 @@ def estimate_prevalences():
         us_2020,
         us_2021,
         nhanes_6_to_49_US_seroprevalence_1999_2004,
-        dutch_seroprevalence_2006,
+        nl_seroprevalence_2006,
         de_adult_seroprevalence_1998,
         adult_seroprevalence_raleigh_durham_US_2020,
     ]

--- a/pathogens/cmv.py
+++ b/pathogens/cmv.py
@@ -20,7 +20,7 @@ pathogen_chars = PathogenChars(
     selection=SelectionRound.ROUND_1,
 )
 
-de_adult_seroprevalence_estimate = Prevalence(
+de_adult_seroprevalence_1998 = Prevalence(
     # Estimate is for 18-79 year olds. In reality, this implies slightly lower
     # than 57% for the overall population including children
     infections_per_100k=0.567 * 100_000,
@@ -32,7 +32,25 @@ de_adult_seroprevalence_estimate = Prevalence(
     source="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6059406/#:~:text=Overall%20CMV%20seroprevalence,Germany%20in%20women",
 )
 
-adult_seroprevalence_raleigh_durham_US = Prevalence(
+dutch_seroprevalence_2006 = Prevalence(
+    # "The CMV seroprevalence in the general population (6 months–79 years)
+    # was 45.6%.""
+    infections_per_100k=0.456 * 100_000,
+    confidence_interval=(0.419 * 100_000, 0.493 * 100_000),  # 95% CI
+    active=Active.LATENT,
+    number_of_participants=6249,
+    # "This study used information from the PIENTER2 project, a crosssectional
+    # population-based serum bank established in 2006–2007.[...]
+    # A total of 19,781 individuals, including 2558 non-Western migrants, were
+    # invited to complete a questionnaire and donate a blood sample. Serum
+    # samples were obtained from 6386 individuals (32%)."
+    source="https://doi.org/10.1016/j.jcv.2014.11.033",  # Page 4, heading 4.2
+    country="Netherlands",
+    date="2006",
+)
+
+
+adult_seroprevalence_raleigh_durham_US_2020 = Prevalence(
     infections_per_100k=0.56 * 100_000,
     # Overall CMV seroprevalence was 56.7% (95%CI: 54.8–58.7%), with a higher
     # seroprevalence in women (62.3%) than in men (51.0%). Seroprevalence
@@ -48,7 +66,7 @@ adult_seroprevalence_raleigh_durham_US = Prevalence(
     source="https://www.frontiersin.org/articles/10.3389/fcimb.2020.00334/full#:~:text=Methods%3A%20We,population%20was%2056%25",
 )
 
-nhanes_6_to_49_US_seroprevalence = Prevalence(
+nhanes_6_to_49_US_seroprevalence_1999_2004 = Prevalence(
     infections_per_100k=0.504 * 100_000,
     country="United States",
     active=Active.LATENT,
@@ -75,17 +93,55 @@ nhanes_6_to_49_US_urine_shedding = Prevalence(
 
 
 def estimate_prevalences():
+    # Extrapolating 2006 Dutch data to Denmark. The prevalence of the
+    # Netherlands looks roughly similar to estimates for Belgium (0.52%),
+    # Germany (0.45%) or Sweden (0.71%) as found in this review of global
+    # CMV seroprevalence:https://doi.org/10.1002/rmv.2034, Figure 2. Specific
+    # numbers are found in the supplement of the same study(https://
+    # onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1002%2Frmv.2034&
+    # file=rmv2034-sup-0001-Appendix_S1.docx.
+    # Note the limitation noted in Issue #198: https://github.com/
+    # naobservatory/p2ra/issues/198
+    dk_2015 = dataclasses.replace(
+        dutch_seroprevalence_2006,
+        date_source=Variable(date="2015"),
+        location_source=Variable(country="Denmark"),
+    )
+    dk_2016 = dataclasses.replace(
+        dk_2015,
+        date_source=Variable(date="2016"),
+    )
+    dk_2017 = dataclasses.replace(
+        dk_2015,
+        date_source=Variable(date="2017"),
+    )
+    dk_2018 = dataclasses.replace(
+        dk_2015,
+        date_source=Variable(date="2018"),
+    )
+    # CMV should be close to constant, so extrapolate from 2003-2010 to
+    # 2020 and 2021.
+    us_2020 = dataclasses.replace(
+        nhanes_6_to_49_US_seroprevalence_1999_2004,
+        date_source=Variable(date="2020"),
+    )
+
+    us_2021 = dataclasses.replace(
+        nhanes_6_to_49_US_seroprevalence_1999_2004,
+        date_source=Variable(date="2021"),
+    )
+
     return [
-        # CMV should be close to constant, so extrapolate from 2003-2010 to
-        # 2020 and 2021.
-        dataclasses.replace(
-            nhanes_6_to_49_US_seroprevalence, date_source=Variable(date="2020")
-        ),
-        dataclasses.replace(
-            nhanes_6_to_49_US_seroprevalence, date_source=Variable(date="2021")
-        ),
-        de_adult_seroprevalence_estimate,
-        adult_seroprevalence_raleigh_durham_US,
+        dk_2015,
+        dk_2016,
+        dk_2017,
+        dk_2018,
+        us_2020,
+        us_2021,
+        nhanes_6_to_49_US_seroprevalence_1999_2004,
+        dutch_seroprevalence_2006,
+        de_adult_seroprevalence_1998,
+        adult_seroprevalence_raleigh_durham_US_2020,
     ]
 
 

--- a/pathogens/cmv.py
+++ b/pathogens/cmv.py
@@ -37,6 +37,7 @@ dutch_seroprevalence_2006 = Prevalence(
     # was 45.6%.""
     infections_per_100k=0.456 * 100_000,
     confidence_interval=(0.419 * 100_000, 0.493 * 100_000),  # 95% CI
+    coverage_probability=0.95,
     active=Active.LATENT,
     number_of_participants=6382,
     # "This study used information from the PIENTER2 project, a crosssectional


### PR DESCRIPTION
See issue #198 for a potentially relevant limitation that we might mention in the limitations of the report, or adjust for ,sometime in the future.

> When extrapolating German or Dutch CMV/EBV estimates for Denmark, we need to think about the share of foreign-born in the extrapolated estimate and in the target location. E.g., foreign-born individuals have markedly higher CMV seroprevalence; if Copenhagen has large non-Western populations, seroprevalence there could thus be higher than in the general population of Germany or the Netherlands.