### PR TITLE
Plot estimates with zero counts differently

### DIFF
--- a/plot_summaries.py
+++ b/plot_summaries.py
@@ -80,7 +80,8 @@ def plot_boxen(
         hue="study",
         hue_order=plotting_order.study.unique(),
         showfliers=False,
-        box_kws={"linewidth": 0.5},
+        box_kws={"linewidth": 0.0},
+        line_kws={"linewidth": 1.0, "color": "0.25"},
     )
 
     lhs = ax.get_xlim()[0]
@@ -113,6 +114,7 @@ def plot_boxen(
                 alpha=0.5,
                 marker="<",
                 s=10,
+                linewidths=0,
             )
 
 
@@ -142,13 +144,15 @@ def plot_incidence(data: pd.DataFrame, input_data: pd.DataFrame) -> plt.Figure:
     ax.set_xlim([1e-14, 1e-4])
     separate_viruses(ax)
     adjust_axes(ax, predictor_type=predictor_type)
-    ax.legend(
+    legend = ax.legend(
         title="MGS study",
         bbox_to_anchor=(1.02, 1),
         loc="upper left",
         borderaxespad=0,
         frameon=False,
     )
+    for legend_handle in legend.legend_handles:
+        legend_handle.set_edgecolor(legend_handle.get_facecolor())
     return fig
 
 
@@ -200,13 +204,15 @@ def plot_prevalence(
         va="top",
     )
     adjust_axes(ax, predictor_type=predictor_type)
-    ax.legend(
+    legend = ax.legend(
         title="MGS study",
         bbox_to_anchor=(1.02, 0),
         loc="lower left",
         borderaxespad=0,
         frameon=False,
     )
+    for legend_handle in legend.legend_handles:
+        legend_handle.set_edgecolor(legend_handle.get_facecolor())
     return fig
 
 

--- a/plot_summaries.py
+++ b/plot_summaries.py
@@ -87,7 +87,7 @@ def plot_boxen(
     for num_reads, line, patches in zip(
         plotting_order.viral_reads, ax.lines, ax.collections
     ):
-        alpha = min(num_reads / 10 + 0.1, 1.0)
+        alpha = min((num_reads + 1) / 10, 1.0)
         line.set_alpha(alpha)
         patches.set_alpha(alpha)
         if (not show_zero_counts) and (num_reads == 0):

--- a/plot_summaries.py
+++ b/plot_summaries.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-import matplotlib.ticker as ticker
-import matplotlib.patches as mpatches
-
 from pathlib import Path
 
+import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt  # type: ignore
+import matplotlib.ticker as ticker
 import numpy as np
 import pandas as pd
 import seaborn as sns  # type: ignore
@@ -102,7 +101,7 @@ def plot_violin(
         else:
             alpha = 1.0
         patches.set_alpha(alpha)
-        # Make violins fatter
+        # Make violins fatter and hatch if zero counts
         for path in patches.get_paths():
             y_mid = path.vertices[0, 1]
             path.vertices[:, 1] = (

--- a/plot_summaries.py
+++ b/plot_summaries.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-import matplotlib.patches as mpatches
+import matplotlib.patches as mpatches  # type: ignore
 import matplotlib.pyplot as plt  # type: ignore
-import matplotlib.ticker as ticker
+import matplotlib.ticker as ticker  # type: ignore
 import numpy as np
 import pandas as pd
 import seaborn as sns  # type: ignore
@@ -339,9 +339,9 @@ def start() -> None:
     fig_prevalence = plot_prevalence(fits_df, input_df)
     save_plot(fig_prevalence, figdir, "prevalence-violin")
     incidence_viruses = {
-        "Norovirus (GII)": (-10, -3),
-        "Norovirus (GI)": (-10, -3),
-        "SARS-COV-2": (-12, -6),
+        "Norovirus (GII)": (-10.0, -3.0),
+        "Norovirus (GI)": (-10.0, -3.0),
+        "SARS-COV-2": (-12.0, -6.0),
     }
     fig_three_virus_incidence = plot_three_virus(
         fits_df, input_df, incidence_viruses, "incidence"

--- a/plot_summaries.py
+++ b/plot_summaries.py
@@ -104,7 +104,6 @@ def plot_boxen(
                 right_edge_midpoint[1],
                 lhs,
                 right_edge_midpoint[0],
-                linestyle="dashed",
                 color=color,
                 alpha=0.1,
             )


### PR DESCRIPTION
For estimates with no viral reads, don't plot the boxes, instead indicate that we have upper bounds on our estimates by plotting:

* Left-pointing triangles at the ~94th percentile
* A faint dashed line to the left edge of the plot

![incidence-boxen](https://github.com/naobservatory/p2ra/assets/18432267/20abb957-34de-4876-aea8-49efd833a4c2)

![prevalence-boxen](https://github.com/naobservatory/p2ra/assets/18432267/1a35d92a-5257-41cb-b2fd-372c9a73eeca)

Note that for the plot by location, we will still plot the boxes since these estimates use information borrowed from the other locations.

![by_location_incidence-boxen](https://github.com/naobservatory/p2ra/assets/18432267/9d487eb4-f355-4e0b-905d-c8c259710916)

One other minor change: we now give the vertical bar for the median the same alpha value as the other elements.