### PR TITLE
pseudocounts: determine fraction of samples this applies to

### DIFF
--- a/determine_pseudocounts.py
+++ b/determine_pseudocounts.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import mgs
+import pathogens
+
+mgs_data = mgs.MGSData.from_repo()
+import stats
+
+for (
+    pathogen_name,
+    tidy_name,
+    predictor_type,
+    taxids,
+    predictors,
+) in pathogens.predictors_by_taxid():
+    if not any(predictor.is_pseudocount for predictor in predictors):
+        continue
+
+    n_samples = 0
+    n_pseudocount_samples = 0
+
+    for study, bioprojects in mgs.target_bioprojects.items():
+        for bioproject in bioprojects:
+            enrichment = None if study == "brinch" else mgs.Enrichment.VIRAL
+            chosen_predictors = {
+                sample: stats.lookup_variables(attrs, predictors)
+                for sample, attrs in mgs_data.sample_attributes(
+                    bioproject, enrichment=enrichment
+                ).items()
+            }
+            if all(ps == [] for ps in chosen_predictors.values()):
+                continue
+            for sample, preds in chosen_predictors.items():
+                (predictor,) = preds
+                n_samples += 1
+                if predictor.is_pseudocount:
+                    n_pseudocount_samples += 1
+
+        print(
+            tidy_name,
+            study,
+            n_pseudocount_samples,
+            n_samples,
+            "%.0f%%" % (100 * n_pseudocount_samples / n_samples),
+        )

--- a/pathogen_properties.py
+++ b/pathogen_properties.py
@@ -122,6 +122,7 @@ class Variable:
     taxid: Optional[TaxID] = None
     inputs: InitVar[Optional[Iterable["Variable"]]] = None
     all_inputs: set["Variable"] = field(default_factory=set)
+    is_pseudocount: Optional[bool] = None
 
     def __post_init__(
         self,
@@ -540,4 +541,4 @@ def by_taxids(
 #
 # It might be better to handle this in the modeling step, but by the time we
 # get to that point the granularity of the input data has been discarded.
-QUANTITY_WHEN_NONE_OBSERVED = 0.1
+QUANTITY_WHEN_NONE_OBSERVED = 0.001

--- a/pathogens/influenza.py
+++ b/pathogens/influenza.py
@@ -234,16 +234,18 @@ def estimate_incidences() -> list[IncidenceRate]:
                 (FLU_B, positive_b),
             ]:
                 adjusted_weekly_count = float(weekly_count)
-                if weekly_count == 0:
-                    # See comment on QUANTITY_WHEN_NONE_OBSERVED.
-                    adjusted_weekly_count = QUANTITY_WHEN_NONE_OBSERVED
-
                 if parsed_start.year <= 2019:
                     continue
 
                 underreporting = get_underreporting(parsed_start, parsed_end)
                 if not underreporting:
                     continue
+
+                is_pseudocount = False
+                if weekly_count == 0:
+                    # See comment on QUANTITY_WHEN_NONE_OBSERVED.
+                    adjusted_weekly_count = QUANTITY_WHEN_NONE_OBSERVED
+                    is_pseudocount = True
 
                 incidence = IncidenceAbsolute(
                     annual_infections=adjusted_weekly_count * 52,
@@ -263,6 +265,7 @@ def estimate_incidences() -> list[IncidenceRate]:
                             * underreporting
                         ),
                         taxid=taxid,
+                        is_pseudocount=is_pseudocount,
                     )
                 )
 


### PR DESCRIPTION
For flu we use pseudocounts to handle cases where we'd otherwise have zero values.  Make a script that tells us how often this happens.

This also involves teaching Variable how to represent whether it's a pseudocount.

```
$ ./determine_pseudocounts.py
Influenza A crits_christoph 7 7 100%
Influenza A rothman 36 104 35%
Influenza A spurbeck 36 159 23%
Influenza A brinch 36 159 23%
Influenza B crits_christoph 7 7 100%
Influenza B rothman 57 104 55%
Influenza B spurbeck 57 159 36%
Influenza B brinch 57 159 36%
```